### PR TITLE
fix(docs): correct plugin installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,11 @@ speclang ships as a Claude Code plugin with two skills that integrate specificat
 
 ### Installation
 
-```bash
-# Add the marketplace
-claude plugins:add-marketplace bamsammich/speclang-marketplace
+In Claude Code, run:
 
-# Enable the plugin
-claude plugins:enable speclang@speclang-marketplace
+```
+/plugin marketplace add bamsammich/speclang-marketplace
+/plugin install speclang@speclang-marketplace
 ```
 
 ### Skills


### PR DESCRIPTION
## Summary

- Fix install commands in README to use `/plugin marketplace add` and `/plugin install` instead of incorrect `claude plugins:` CLI commands

## Test Plan

- [ ] README install instructions match superpowers convention