### PR TITLE
fix: drop macOS release binaries, add go install instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,6 @@ jobs:
             goarch: amd64
           - goos: linux
             goarch: arm64
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -23,11 +23,19 @@ The test surface is unknowable to the implementer because inputs are generated f
 
 ## Getting Started
 
-### Prerequisites
+### Install
 
-- Go (latest stable)
+**With Go (macOS or Linux):**
 
-### Build
+```bash
+go install github.com/bamsammich/speclang/cmd/specrun@latest
+```
+
+**Pre-built binary (Linux only):**
+
+Download from [releases](https://github.com/bamsammich/speclang/releases). macOS binaries are not provided because unsigned binaries are blocked by Gatekeeper — use `go install` instead.
+
+**From source:**
 
 ```bash
 go build -o specrun ./cmd/specrun


### PR DESCRIPTION
## Summary

- Remove darwin builds from release workflow (unsigned binaries are blocked by Gatekeeper)
- Add `go install` as the recommended install method for macOS
- Add pre-built binary instructions for Linux with link to releases

## Test Plan

- [ ] CI passes
- [ ] README install instructions are clear