### PR TITLE
feat: relational assertions in then blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ spec AccountAPI {
       output.to.balance >= 0
     }
 
-    # Smoke test with concrete values.
+    # Smoke test: expected values computed from input, not hardcoded.
     scenario success {
       given {
         from: { id: "alice", balance: 100 }
@@ -100,8 +100,8 @@ spec AccountAPI {
         amount: 30
       }
       then {
-        from.balance: 70
-        to.balance: 80
+        from.balance: from.balance - amount
+        to.balance: to.balance + amount
         error: null
       }
     }

--- a/examples/scopes/transfer.spec
+++ b/examples/scopes/transfer.spec
@@ -45,8 +45,8 @@ scope transfer {
       amount: 30
     }
     then {
-      from.balance: 70
-      to.balance: 80
+      from.balance: from.balance - amount
+      to.balance: to.balance + amount
       error: null
     }
   }

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -186,6 +186,16 @@ func (c *evalCtx) eval(expr parser.Expr) (any, bool) {
 		return c.resolveRef(e.Path)
 	case parser.BinaryOp:
 		return c.evalBinary(e)
+	case parser.ObjectLiteral:
+		m := make(map[string]any, len(e.Fields))
+		for _, f := range e.Fields {
+			v, ok := c.eval(f.Value)
+			if !ok {
+				return nil, false
+			}
+			m[f.Key] = v
+		}
+		return m, true
 	case parser.UnaryOp:
 		return c.evalUnary(e)
 	default:

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -348,9 +348,9 @@ func TestParseTransferSpec(t *testing.T) {
 		if sc.Then.Assertions[0].Target != "from.balance" {
 			t.Errorf("expected target 'from.balance', got %q", sc.Then.Assertions[0].Target)
 		}
-		expectedVal, ok := sc.Then.Assertions[0].Expected.(parser.LiteralInt)
-		if !ok || expectedVal.Value != 70 {
-			t.Errorf("expected LiteralInt{70}, got %v", sc.Then.Assertions[0].Expected)
+		binOp, ok := sc.Then.Assertions[0].Expected.(parser.BinaryOp)
+		if !ok || binOp.Op != "-" {
+			t.Errorf("expected BinaryOp{-}, got %v", sc.Then.Assertions[0].Expected)
 		}
 		// error: null
 		if sc.Then.Assertions[2].Target != "error" {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -348,7 +348,11 @@ func (sr *scopeRunner) checkThenAssertions(
 	then *parser.Block,
 ) (*Failure, error) {
 	for _, a := range then.Assertions {
-		expected, err := exprToJSON(a.Expected)
+		val, ok := generator.Eval(a.Expected, input)
+		if !ok {
+			return nil, fmt.Errorf("evaluating expected expression for %q", a.Target)
+		}
+		expected, err := json.Marshal(val)
 		if err != nil {
 			return nil, fmt.Errorf("marshaling expected for %q: %w", a.Target, err)
 		}

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -102,6 +102,68 @@ func TestVerify_ScopeResults(t *testing.T) {
 	}
 }
 
+func TestRelationalAssertions(t *testing.T) {
+	t.Parallel()
+
+	// Build a spec with relational then-assertions programmatically.
+	spec := &parser.Spec{
+		Name: "RelTest",
+		Uses: []string{"http"},
+		Scopes: []*parser.Scope{{
+			Name: "math",
+			Config: map[string]parser.Expr{
+				"path":   parser.LiteralString{Value: "/add"},
+				"method": parser.LiteralString{Value: "POST"},
+			},
+			Scenarios: []*parser.Scenario{{
+				Name: "relational",
+				Given: &parser.Block{
+					Assignments: []*parser.Assignment{
+						{Path: "a", Value: parser.LiteralInt{Value: 7}},
+						{Path: "b", Value: parser.LiteralInt{Value: 3}},
+					},
+				},
+				Then: &parser.Block{
+					Assertions: []*parser.Assertion{
+						{
+							Target: "sum",
+							Expected: parser.BinaryOp{
+								Left: parser.FieldRef{Path: "a"},
+								Op:   "+",
+								Right: parser.FieldRef{Path: "b"},
+							},
+						},
+					},
+				},
+			}},
+		}},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /add", func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]int
+		json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]int{"sum": req["a"] + req["b"]})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	adp := adapter.NewHTTPAdapter()
+	if err := adp.Init(map[string]string{"base_url": srv.URL}); err != nil {
+		t.Fatal(err)
+	}
+
+	r := runner.New(spec, adp, 1)
+	res, err := r.Verify()
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if len(res.Failures) > 0 {
+		t.Errorf("expected no failures, got %v", res.Failures[0].Description)
+	}
+}
+
 func TestVerifyTransferSpec(t *testing.T) {
 	spec, err := parser.ParseFile("../../examples/transfer.spec")
 	if err != nil {

--- a/skills/author/SKILL.md
+++ b/skills/author/SKILL.md
@@ -31,9 +31,11 @@ Convert natural language requirements into speclang specification files.
 
 | Pattern | Use when | Example |
 |---------|----------|---------|
-| `given` scenario | Documenting a specific expected behavior | "Transferring 30 from Alice(100) to Bob(50) should work" |
+| `given` scenario | Documenting a specific expected behavior (use relational assertions to compute expected values from input) | "Transferring 30 from Alice(100) to Bob(50) should work" |
 | `when` scenario | An entire class of inputs should produce the same outcome | "Any amount exceeding balance should fail" |
 | `invariant` | A property that must hold universally | "Money is conserved across transfers" |
+
+**Prefer relational assertions in `then` blocks** — write `from.balance: from.balance - amount` instead of `from.balance: 70`. This computes the expected value from the input, so the assertion adapts to any input and resists memorization. Literal values are still supported where appropriate (e.g., `error: null`).
 
 **Prefer invariants over scenarios when possible.** Invariants are the strongest form of verification — they test across the full input space, not just a slice.
 

--- a/skills/author/references/api_reference.md
+++ b/skills/author/references/api_reference.md
@@ -82,6 +82,8 @@ invariant conservation { ... }
 
 Fixed input values. Runs once. Documents expected behavior.
 
+`then` assertions can use **relational expressions** that reference input fields. The expected value is computed from the input, not hardcoded. This makes assertions resistant to memorization — an LLM can't learn "the answer is 70" because the answer depends on the input.
+
 ```
 scenario success {
   given {
@@ -90,8 +92,9 @@ scenario success {
     amount: 30
   }
   then {
-    from.balance: 70
-    to.balance: 80
+    from.balance: from.balance - amount   # 100 - 30 = 70
+    to.balance: to.balance + amount       # 50 + 30 = 80
+    error: null                           # literals still work
   }
 }
 ```


### PR DESCRIPTION
## Summary

- `then` block assertions now support expressions that reference input fields (e.g., `from.balance: from.balance - amount`) instead of only literal values
- Expected values are computed from the input at runtime, making concrete scenarios resist memorization and adjust automatically when given values change
- Backward compatible — literal assertions still work unchanged

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New `TestRelationalAssertions` validates expression evaluation end-to-end
- [x] `specrun verify examples/transfer.spec` passes with relational assertions
- [x] `specrun verify specs/speclang.spec` self-verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)