### PR TITLE
feat(parser): add import keyword and resolver dispatch

### DIFF
--- a/pkg/parser/import.go
+++ b/pkg/parser/import.go
@@ -1,0 +1,73 @@
+package parser
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// ImportResolver converts an external schema file into speclang AST nodes.
+type ImportResolver interface {
+	Resolve(absPath string) ([]*Model, []*Scope, error)
+}
+
+// ImportRegistry maps adapter names (e.g., "openapi") to their resolvers.
+type ImportRegistry map[string]ImportResolver
+
+// importResult wraps models and scopes returned by an import resolver
+// for dispatch by parseSpecMember.
+type importResult struct {
+	Models []*Model
+	Scopes []*Scope
+}
+
+// parseImport parses: import <adapter>("<path>")
+func (p *parser) parseImport() (*importResult, error) {
+	importTok := p.peek()
+	p.advance() // consume "import"
+
+	// Read adapter name identifier (e.g., "openapi")
+	adapterTok := p.peek()
+	if adapterTok.Type != TokenIdent {
+		return nil, p.errAt(adapterTok, fmt.Sprintf("expected import adapter name, got %s", adapterTok.Type))
+	}
+	p.advance()
+
+	// Expect ( "path" )
+	if _, err := p.expect(TokenLParen); err != nil {
+		return nil, err
+	}
+	pathTok, err := p.expect(TokenString)
+	if err != nil {
+		return nil, p.errAt(p.peek(), "expected string path in import")
+	}
+	if _, err := p.expect(TokenRParen); err != nil {
+		return nil, err
+	}
+
+	// Look up resolver
+	if p.imports == nil {
+		return nil, p.errAt(importTok, fmt.Sprintf("no import resolvers registered (for %q)", adapterTok.Value))
+	}
+	resolver, ok := p.imports[adapterTok.Value]
+	if !ok {
+		return nil, p.errAt(adapterTok, fmt.Sprintf("unknown import adapter %q", adapterTok.Value))
+	}
+
+	// Resolve path relative to spec file directory
+	relPath := pathTok.Value
+	absPath := relPath
+	if p.fileDir != "" {
+		absPath = filepath.Join(p.fileDir, relPath)
+	}
+	resolved, err := filepath.Abs(absPath)
+	if err != nil {
+		return nil, p.errAt(pathTok, fmt.Sprintf("resolving import path: %v", err))
+	}
+
+	models, scopes, err := resolver.Resolve(resolved)
+	if err != nil {
+		return nil, p.errAt(pathTok, fmt.Sprintf("import %s(%q): %v", adapterTok.Value, relPath, err))
+	}
+
+	return &importResult{Models: models, Scopes: scopes}, nil
+}

--- a/pkg/parser/import_test.go
+++ b/pkg/parser/import_test.go
@@ -1,0 +1,314 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// mockResolver implements ImportResolver for testing.
+type mockResolver struct {
+	models []*Model
+	scopes []*Scope
+	err    error
+}
+
+func (m *mockResolver) Resolve(absPath string) ([]*Model, []*Scope, error) {
+	return m.models, m.scopes, m.err
+}
+
+func TestLexImportKeyword(t *testing.T) {
+	tokens, err := Lex(`import openapi("schema.yaml")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tokens[0].Type != TokenImport {
+		t.Errorf("expected TokenImport, got %s", tokens[0].Type)
+	}
+	if tokens[0].Value != "import" {
+		t.Errorf("expected value 'import', got %q", tokens[0].Value)
+	}
+}
+
+func TestParseImport_Basic(t *testing.T) {
+	dir := t.TempDir()
+	specFile := filepath.Join(dir, "test.spec")
+	os.WriteFile(specFile, []byte(`
+use http
+spec Test {
+  import test("schema.yaml")
+}
+`), 0644)
+
+	resolver := &mockResolver{
+		models: []*Model{
+			{Name: "Pet", Fields: []*Field{
+				{Name: "id", Type: TypeExpr{Name: "int"}},
+				{Name: "name", Type: TypeExpr{Name: "string"}},
+			}},
+		},
+		scopes: []*Scope{
+			{
+				Name: "list_pets",
+				Config: map[string]Expr{
+					"path":   LiteralString{Value: "/pets"},
+					"method": LiteralString{Value: "GET"},
+				},
+			},
+		},
+	}
+
+	registry := ImportRegistry{"test": resolver}
+	spec, err := ParseFileWithImports(specFile, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(spec.Models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(spec.Models))
+	}
+	if spec.Models[0].Name != "Pet" {
+		t.Errorf("expected model name 'Pet', got %q", spec.Models[0].Name)
+	}
+	if len(spec.Models[0].Fields) != 2 {
+		t.Errorf("expected 2 fields, got %d", len(spec.Models[0].Fields))
+	}
+
+	if len(spec.Scopes) != 1 {
+		t.Fatalf("expected 1 scope, got %d", len(spec.Scopes))
+	}
+	if spec.Scopes[0].Name != "list_pets" {
+		t.Errorf("expected scope name 'list_pets', got %q", spec.Scopes[0].Name)
+	}
+}
+
+func TestParseImport_MergesWithHandWritten(t *testing.T) {
+	dir := t.TempDir()
+	specFile := filepath.Join(dir, "test.spec")
+	os.WriteFile(specFile, []byte(`
+use http
+spec Test {
+  model Local {
+    id: int
+  }
+  import test("schema.yaml")
+  scope local_scope {
+    contract {
+      input { x: int }
+      output { y: int }
+    }
+  }
+}
+`), 0644)
+
+	resolver := &mockResolver{
+		models: []*Model{
+			{Name: "Imported", Fields: []*Field{{Name: "a", Type: TypeExpr{Name: "string"}}}},
+		},
+		scopes: []*Scope{
+			{Name: "imported_scope"},
+		},
+	}
+
+	registry := ImportRegistry{"test": resolver}
+	spec, err := ParseFileWithImports(specFile, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(spec.Models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(spec.Models))
+	}
+	if len(spec.Scopes) != 2 {
+		t.Fatalf("expected 2 scopes, got %d", len(spec.Scopes))
+	}
+
+	modelNames := map[string]bool{}
+	for _, m := range spec.Models {
+		modelNames[m.Name] = true
+	}
+	if !modelNames["Local"] || !modelNames["Imported"] {
+		t.Errorf("expected models Local and Imported, got %v", modelNames)
+	}
+
+	scopeNames := map[string]bool{}
+	for _, s := range spec.Scopes {
+		scopeNames[s.Name] = true
+	}
+	if !scopeNames["local_scope"] || !scopeNames["imported_scope"] {
+		t.Errorf("expected scopes local_scope and imported_scope, got %v", scopeNames)
+	}
+}
+
+func TestParseImport_UnknownAdapter(t *testing.T) {
+	dir := t.TempDir()
+	specFile := filepath.Join(dir, "test.spec")
+	os.WriteFile(specFile, []byte(`
+use http
+spec Test {
+  import unknown("schema.yaml")
+}
+`), 0644)
+
+	registry := ImportRegistry{"openapi": &mockResolver{}}
+	_, err := ParseFileWithImports(specFile, registry)
+	if err == nil {
+		t.Fatal("expected error for unknown adapter")
+	}
+	if !strings.Contains(err.Error(), "unknown import adapter") {
+		t.Errorf("expected 'unknown import adapter' in error, got: %v", err)
+	}
+}
+
+func TestParseImport_NilRegistry(t *testing.T) {
+	dir := t.TempDir()
+	specFile := filepath.Join(dir, "test.spec")
+	os.WriteFile(specFile, []byte(`
+use http
+spec Test {
+  import openapi("schema.yaml")
+}
+`), 0644)
+
+	_, err := ParseFileWithImports(specFile, nil)
+	if err == nil {
+		t.Fatal("expected error for nil registry")
+	}
+	if !strings.Contains(err.Error(), "no import resolvers registered") {
+		t.Errorf("expected 'no import resolvers registered' in error, got: %v", err)
+	}
+}
+
+func TestParseImport_ResolverError(t *testing.T) {
+	dir := t.TempDir()
+	specFile := filepath.Join(dir, "test.spec")
+	os.WriteFile(specFile, []byte(`
+use http
+spec Test {
+  import test("bad.yaml")
+}
+`), 0644)
+
+	resolver := &mockResolver{err: fmt.Errorf("file not found")}
+	registry := ImportRegistry{"test": resolver}
+	_, err := ParseFileWithImports(specFile, registry)
+	if err == nil {
+		t.Fatal("expected error from resolver")
+	}
+	if !strings.Contains(err.Error(), "file not found") {
+		t.Errorf("expected 'file not found' in error, got: %v", err)
+	}
+}
+
+func TestParseImport_DuplicateModelName(t *testing.T) {
+	dir := t.TempDir()
+	specFile := filepath.Join(dir, "test.spec")
+	os.WriteFile(specFile, []byte(`
+use http
+spec Test {
+  model Pet {
+    id: int
+  }
+  import test("schema.yaml")
+}
+`), 0644)
+
+	resolver := &mockResolver{
+		models: []*Model{
+			{Name: "Pet", Fields: []*Field{{Name: "name", Type: TypeExpr{Name: "string"}}}},
+		},
+	}
+
+	registry := ImportRegistry{"test": resolver}
+	_, err := ParseFileWithImports(specFile, registry)
+	if err == nil {
+		t.Fatal("expected error for duplicate model name")
+	}
+	if !strings.Contains(err.Error(), "duplicate") && !strings.Contains(err.Error(), "Pet") {
+		t.Errorf("expected duplicate error mentioning 'Pet', got: %v", err)
+	}
+}
+
+func TestParseImport_DuplicateScopeName(t *testing.T) {
+	dir := t.TempDir()
+	specFile := filepath.Join(dir, "test.spec")
+	os.WriteFile(specFile, []byte(`
+use http
+spec Test {
+  scope my_scope {
+    contract {
+      input { x: int }
+      output { y: int }
+    }
+  }
+  import test("schema.yaml")
+}
+`), 0644)
+
+	resolver := &mockResolver{
+		scopes: []*Scope{
+			{Name: "my_scope"},
+		},
+	}
+
+	registry := ImportRegistry{"test": resolver}
+	_, err := ParseFileWithImports(specFile, registry)
+	if err == nil {
+		t.Fatal("expected error for duplicate scope name")
+	}
+	if !strings.Contains(err.Error(), "duplicate") && !strings.Contains(err.Error(), "my_scope") {
+		t.Errorf("expected duplicate error mentioning 'my_scope', got: %v", err)
+	}
+}
+
+func TestParseImport_EmptyResult(t *testing.T) {
+	dir := t.TempDir()
+	specFile := filepath.Join(dir, "test.spec")
+	os.WriteFile(specFile, []byte(`
+use http
+spec Test {
+  import test("empty.yaml")
+}
+`), 0644)
+
+	resolver := &mockResolver{models: nil, scopes: nil}
+	registry := ImportRegistry{"test": resolver}
+	spec, err := ParseFileWithImports(specFile, registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(spec.Models) != 0 {
+		t.Errorf("expected 0 models, got %d", len(spec.Models))
+	}
+	if len(spec.Scopes) != 0 {
+		t.Errorf("expected 0 scopes, got %d", len(spec.Scopes))
+	}
+}
+
+func TestParseImport_SyntaxError_MissingParen(t *testing.T) {
+	src := `
+use http
+spec Test {
+  import openapi "schema.yaml"
+}
+`
+	_, err := Parse(src)
+	if err == nil {
+		t.Fatal("expected parse error for missing parens")
+	}
+}
+
+func TestParseImport_SyntaxError_MissingPath(t *testing.T) {
+	src := `
+use http
+spec Test {
+  import openapi()
+}
+`
+	_, err := Parse(src)
+	if err == nil {
+		t.Fatal("expected parse error for missing path")
+	}
+}

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -52,6 +52,7 @@ const (
 	TokenConfig
 	TokenEnv
 	TokenInclude
+	TokenImport
 
 	// Symbols
 	TokenLBrace   // {
@@ -111,6 +112,7 @@ var tokenNames = map[TokenType]string{
 	TokenConfig:    "Config",
 	TokenEnv:       "Env",
 	TokenInclude:   "Include",
+	TokenImport:    "Import",
 	TokenLBrace:    "LBrace",
 	TokenRBrace:    "RBrace",
 	TokenLParen:    "LParen",
@@ -167,6 +169,7 @@ var keywords = map[string]TokenType{
 	"config":    TokenConfig,
 	"env":       TokenEnv,
 	"include":   TokenInclude,
+	"import":    TokenImport,
 	"true":      TokenBool,
 	"false":     TokenBool,
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -8,6 +8,12 @@ import (
 
 // ParseFile reads a spec file, resolves includes, and returns the AST.
 func ParseFile(path string) (*Spec, error) {
+	return ParseFileWithImports(path, nil)
+}
+
+// ParseFileWithImports reads a spec file, resolves includes, and returns the AST.
+// The imports registry maps adapter names to import resolvers for the import directive.
+func ParseFileWithImports(path string, imports ImportRegistry) (*Spec, error) {
 	absRoot, err := filepath.Abs(path)
 	if err != nil {
 		return nil, fmt.Errorf("resolving path: %w", err)
@@ -23,7 +29,11 @@ func ParseFile(path string) (*Spec, error) {
 		return nil, err
 	}
 
-	p := &parser{tokens: resolved}
+	p := &parser{
+		tokens:  resolved,
+		imports: imports,
+		fileDir: filepath.Dir(absRoot),
+	}
 	spec, err := p.parse()
 	if err != nil {
 		return nil, err
@@ -47,8 +57,10 @@ func Parse(source string) (*Spec, error) {
 }
 
 type parser struct {
-	tokens []Token
-	pos    int
+	tokens  []Token
+	imports ImportRegistry
+	fileDir string // directory of the spec file, for relative path resolution
+	pos     int
 }
 
 // peek returns the current token without consuming it.
@@ -166,6 +178,8 @@ func (p *parser) specMemberParser(typ TokenType) func() (any, error) {
 		return wrap(p.parseLocators)
 	case TokenScope:
 		return wrap(p.parseScope)
+	case TokenImport:
+		return wrap(p.parseImport)
 	default:
 		return nil
 	}
@@ -214,6 +228,9 @@ func (p *parser) parseSpecMember(spec *Spec) error {
 		spec.Scopes = append(spec.Scopes, v)
 	case map[string]string:
 		spec.Locators = v
+	case *importResult:
+		spec.Models = append(spec.Models, v.Models...)
+		spec.Scopes = append(spec.Scopes, v.Scopes...)
 	}
 	return nil
 }

--- a/specs/parse.spec
+++ b/specs/parse.spec
@@ -67,4 +67,24 @@ scope parse_invalid {
       exit_code: 1
     }
   }
+
+  # Import with no resolver registered should fail gracefully.
+  scenario import_no_resolver {
+    given {
+      file: "testdata/openapi/import_no_resolver.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # Import with bad syntax (missing parens) should fail.
+  scenario import_bad_syntax {
+    given {
+      file: "testdata/openapi/import_bad_syntax.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
 }

--- a/testdata/openapi/import_bad_syntax.spec
+++ b/testdata/openapi/import_bad_syntax.spec
@@ -1,0 +1,4 @@
+use http
+spec ImportTest {
+  import openapi "missing_parens.yaml"
+}

--- a/testdata/openapi/import_no_resolver.spec
+++ b/testdata/openapi/import_no_resolver.spec
@@ -1,0 +1,4 @@
+use http
+spec ImportTest {
+  import openapi("petstore.yaml")
+}

--- a/testdata/openapi/petstore.yaml
+++ b/testdata/openapi/petstore.yaml
@@ -1,0 +1,52 @@
+openapi: "3.0.0"
+info:
+  title: Petstore
+  version: "1.0.0"
+paths:
+  /pets:
+    get:
+      operationId: list_pets
+      responses:
+        "200":
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+    post:
+      operationId: create_pet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "201":
+          description: Created pet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        tag:
+          type: string
+    Owner:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+        name:
+          type: string


### PR DESCRIPTION
## Summary

- Adds `import` as a language keyword with the syntax `import <adapter>("path")`
- Introduces `ImportResolver` interface and `ImportRegistry` for pluggable schema format support
- Adds `ParseFileWithImports()` to thread the registry into the parser
- Wires dispatch into `specMemberParser` — imported models/scopes merge into the spec AST
- Existing `validateNoDuplicates` catches name collisions between imported and hand-written definitions
- `ParseFile()` delegates to `ParseFileWithImports(path, nil)` for backward compatibility

## Test plan

- [x] 11 unit tests covering: basic import, merge with hand-written, unknown adapter, nil registry, resolver error, duplicate model/scope names, empty result, syntax errors
- [x] Self-verification scenarios: `import_no_resolver` and `import_bad_syntax` in `specs/parse.spec`
- [x] All existing tests pass (no breaking changes)
- [x] `go test ./... -count=1` green
- [x] `SPECRUN_BIN=./specrun ./specrun verify specs/speclang.spec` — import scenarios pass

Closes #11