### PR TITLE
feat: wire OpenAPI import end-to-end with docs and examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ spec <Name> {
   }
 
   include "<path>"                   # spec-body include
+  import openapi("<path>")           # import models/scopes from OpenAPI schema
 
   locators {                         # UI-mode only
     <name>: [<css-selector>]
@@ -96,6 +97,26 @@ spec <Name> {
 - **Downstream transparency**: generator, runner, and adapter see a single merged `*Spec` — no include-awareness needed
 
 The include is resolved at the token level (pass 1) before parsing (pass 2). The parser has zero awareness of includes.
+
+### Import Directive
+
+`import <adapter>("path")` imports models and scopes from an external schema file. The adapter name determines the format (currently only `openapi` is supported).
+
+```
+import openapi("schema.yaml")
+```
+
+- **Paths are relative** to the spec file's directory
+- **OpenAPI 3.x** (YAML or JSON) schemas are supported via [kin-openapi](https://github.com/getkin/kin-openapi)
+- **Models** are generated from `components/schemas` (object types with properties)
+- **Scopes** are generated from `paths` (each path+method → scope with config and contract)
+- **Type mapping**: `integer` → `int`, `string` → `string`, `boolean` → `bool`, `$ref` → model name
+- **Constraints**: `minimum`/`maximum` → field constraint expressions
+- **Unsupported types** (array, float, enum) are skipped with a warning
+- **Duplicate model or scope names** between imported and hand-written produce an error
+- **Downstream transparency**: generator, runner, and adapter see standard AST nodes — no import-awareness needed
+
+The import is resolved at parse time. The parser dispatches to a pluggable `ImportResolver` based on the adapter name.
 
 ### Scope and Declaration Rules
 
@@ -219,7 +240,8 @@ speclang/
 │   │   ├── lexer.go
 │   │   ├── parser.go
 │   │   ├── ast.go
-│   │   └── include.go    # include resolution + duplicate validation
+│   │   ├── include.go    # include resolution + duplicate validation
+│   │   └── import.go     # import directive + ImportResolver interface
 │   ├── generator/        # AST → test inputs
 │   │   ├── generator.go
 │   │   └── shrink.go     # counterexample shrinking
@@ -229,6 +251,11 @@ speclang/
 │   │   ├── protocol.go   # JSON IPC types
 │   │   ├── http.go       # built-in HTTP adapter
 │   │   └── process.go    # built-in process adapter (subprocess execution)
+│   ├── openapi/          # OpenAPI import resolver
+│   │   ├── openapi.go    # Resolver implementing ImportResolver
+│   │   ├── document.go   # OpenAPI doc loading via kin-openapi
+│   │   ├── models.go     # schema → Model conversion
+│   │   └── scopes.go     # path → Scope conversion
 │   └── plugin/           # plugin spec loading
 │       └── plugin.go
 ├── plugins/
@@ -240,6 +267,9 @@ speclang/
 │   │   └── account.spec  # model Account
 │   ├── scopes/
 │   │   └── transfer.spec # scope transfer (contract, invariants, scenarios)
+│   ├── openapi/          # OpenAPI import example
+│   │   ├── petstore.yaml # sample OpenAPI 3.0 spec
+│   │   └── petstore.spec # spec importing from OpenAPI schema
 │   └── server/           # trivial Go HTTP server to test against
 │       └── main.go
 ├── specs/                # self-verification specs (speclang verifying itself)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,26 @@ Trigger with `/verify-spec` or automatically before creating PRs in projects wit
 
 When working in a project with `.spec` files, the plugin automatically detects them and reminds Claude that speclang skills are available.
 
+## OpenAPI Import
+
+If you have an existing OpenAPI 3.x schema, you can import models and scope scaffolds directly:
+
+```
+use http
+
+spec MyAPI {
+  target {
+    base_url: env(APP_URL, "http://localhost:8080")
+  }
+
+  import openapi("schema.yaml")
+}
+```
+
+This generates models from `components/schemas` and scopes from `paths`, letting you layer invariants and scenarios on top of your existing API definition.
+
+See [docs/openapi-import.md](docs/openapi-import.md) for the full guide, type mapping, and limitations.
+
 ## Plugins
 
 speclang uses a plugin architecture for interacting with different systems:

--- a/cmd/specrun/main.go
+++ b/cmd/specrun/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bamsammich/speclang/pkg/adapter"
 	"github.com/bamsammich/speclang/pkg/generator"
+	"github.com/bamsammich/speclang/pkg/openapi"
 	"github.com/bamsammich/speclang/pkg/parser"
 	"github.com/bamsammich/speclang/pkg/runner"
 )
@@ -40,7 +41,7 @@ func runParse(args []string) int {
 	}
 	specFile := args[0]
 
-	spec, err := parser.ParseFile(specFile)
+	spec, err := parser.ParseFileWithImports(specFile, defaultImports())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "parse error: %v\n", err)
 		return 1
@@ -94,7 +95,7 @@ func runGenerate(args []string) int {
 		return 1
 	}
 
-	spec, err := parser.ParseFile(specFile)
+	spec, err := parser.ParseFileWithImports(specFile, defaultImports())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "parse error: %v\n", err)
 		return 1
@@ -145,7 +146,7 @@ func runVerify(args []string) int {
 	}
 	specFile := fs.Arg(0)
 
-	spec, err := parser.ParseFile(specFile)
+	spec, err := parser.ParseFileWithImports(specFile, defaultImports())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "parse error: %v\n", err)
 		return 1
@@ -292,5 +293,12 @@ func resolveExprToString(expr parser.Expr) string {
 		return e.Default
 	default:
 		return fmt.Sprintf("%v", e)
+	}
+}
+
+// defaultImports returns the built-in import registry with all supported adapters.
+func defaultImports() parser.ImportRegistry {
+	return parser.ImportRegistry{
+		"openapi": &openapi.Resolver{},
 	}
 }

--- a/docs/openapi-import.md
+++ b/docs/openapi-import.md
@@ -1,0 +1,144 @@
+# Working with OpenAPI Schemas in Speclang
+
+Speclang can import models and scope scaffolds directly from OpenAPI 3.x schema files. This lets you start from an existing API definition and layer verification properties (invariants, scenarios) on top.
+
+## Quick Start
+
+Given an OpenAPI spec `api.yaml`:
+
+```yaml
+openapi: "3.0.0"
+info:
+  title: My API
+  version: "1.0.0"
+paths:
+  /users:
+    post:
+      operationId: create_user
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+components:
+  schemas:
+    User:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: integer
+          minimum: 1
+        name:
+          type: string
+        email:
+          type: string
+```
+
+Write a speclang spec that imports it:
+
+```
+use http
+
+spec MyAPI {
+  target {
+    base_url: env(APP_URL, "http://localhost:8080")
+  }
+
+  import openapi("api.yaml")
+
+  # The import generates:
+  #   model User { id: int { 1 <= id }  name: string  email: string? }
+  #   scope create_user { config { path: "/users"  method: "POST" }  contract { ... } }
+}
+```
+
+Then verify:
+
+```bash
+specrun verify myapi.spec
+```
+
+## What Gets Imported
+
+### Models (from `components/schemas`)
+
+Each OpenAPI schema with `type: object` and `properties` becomes a speclang model.
+
+| OpenAPI | Speclang | Notes |
+|---------|----------|-------|
+| `type: integer` | `int` | Direct mapping |
+| `type: string` | `string` | Direct mapping |
+| `type: boolean` | `bool` | Direct mapping |
+| `$ref: "#/.../Name"` | `Name` | Model name reference |
+| `type: number` | `int` | Mapped with warning (no float type) |
+| `type: array` | — | Skipped with warning |
+| `enum` | — | Skipped with warning |
+
+Fields listed in the schema's `required` array become non-optional; others become optional (`type?`).
+
+### Constraints (from validation keywords)
+
+| OpenAPI | Speclang constraint |
+|---------|-------------------|
+| `minimum: N` | `N <= field` |
+| `maximum: N` | `field <= N` |
+| `exclusiveMinimum: true` + `minimum: N` | `N < field` |
+| `exclusiveMaximum: true` + `maximum: N` | `field < N` |
+| Both min and max | Combined with `&&` |
+
+### Scopes (from `paths`)
+
+Each path + HTTP method becomes a scope:
+
+- **Scope name**: `operationId` if present, otherwise `<method>_<sanitized_path>` (e.g., `post_api_v1_users`)
+- **Config**: `path` and `method` populated from the OpenAPI path and HTTP method
+- **Contract input**: Fields from the `requestBody` JSON schema
+- **Contract output**: Fields from the `200` or `201` response JSON schema
+- **No invariants or scenarios**: Those are hand-authored
+
+## Adding Verification Properties
+
+Imported scopes are scaffolds. The real value comes from adding invariants and scenarios:
+
+```
+use http
+
+spec MyAPI {
+  target {
+    base_url: env(APP_URL, "http://localhost:8080")
+  }
+
+  import openapi("api.yaml")
+
+  # You can reference imported models in hand-written scopes,
+  # or add invariants/scenarios to imported scopes by defining
+  # them in separate included files.
+}
+```
+
+Since invariants and scenarios must live inside scope blocks, and imported scopes are generated without them, you can define additional scopes that share the same contract or write complementary scopes in included files.
+
+## Limitations
+
+- **Array types**: OpenAPI `type: array` is not supported in speclang. Array fields are skipped with a warning.
+- **Float types**: OpenAPI `type: number` (float) is mapped to `int` with a warning.
+- **Enum types**: Not supported. Enum fields are mapped to their base type without value enforcement.
+- **Composition**: `oneOf`, `anyOf`, `allOf` are not directly supported.
+- **External $ref**: Only internal references (`#/components/schemas/...`) are resolved. File-based `$ref` is not supported.
+- **Path parameters**: Not yet mapped to contract input fields.
+
+## Example
+
+See [`examples/openapi/`](../examples/openapi/) for a complete example importing a Petstore API.
+
+## Technical Details
+
+The import uses [kin-openapi](https://github.com/getkin/kin-openapi) for parsing and `$ref` resolution, so it stays current with OpenAPI spec evolution. The converter produces standard speclang AST nodes (`*Model`, `*Scope`), making imported schemas indistinguishable from hand-written ones to the generator, runner, and adapter.

--- a/examples/openapi/petstore.spec
+++ b/examples/openapi/petstore.spec
@@ -1,0 +1,19 @@
+use http
+
+spec PetstoreAPI {
+  description: "Pet store API imported from OpenAPI schema"
+
+  target {
+    base_url: env(APP_URL, "http://localhost:8080")
+  }
+
+  # Import models and scope scaffolds from OpenAPI schema.
+  import openapi("petstore.yaml")
+
+  # The import generates:
+  #   model Pet { id: int { 1 <= id }  name: string  tag: string? }
+  #   scope create_pet { config { path: "/pets"  method: "POST" } contract { ... } }
+  #   scope list_pets  { config { path: "/pets"  method: "GET" }  contract { ... } }
+  #
+  # Add invariants and scenarios on top of the imported scaffolds.
+}

--- a/examples/openapi/petstore.yaml
+++ b/examples/openapi/petstore.yaml
@@ -1,0 +1,44 @@
+openapi: "3.0.0"
+info:
+  title: Petstore
+  version: "1.0.0"
+paths:
+  /pets:
+    get:
+      operationId: list_pets
+      responses:
+        "200":
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+    post:
+      operationId: create_pet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "201":
+          description: Created pet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          minimum: 1
+        name:
+          type: string
+        tag:
+          type: string

--- a/skills/author/SKILL.md
+++ b/skills/author/SKILL.md
@@ -16,6 +16,7 @@ Convert natural language requirements into speclang specification files.
 
 ## Spec Writing Checklist
 
+- [ ] If the user has an OpenAPI spec, use `import openapi("path")` to import models and scopes
 - [ ] `use <plugin>` at the top
 - [ ] `spec <Name>` with a `description` explaining what the system is
 - [ ] `target` block with connection config

--- a/skills/author/references/api_reference.md
+++ b/skills/author/references/api_reference.md
@@ -150,6 +150,22 @@ include "models/account.spec"
 include "scopes/transfer.spec"
 ```
 
+## Import Directive
+
+Import models and scopes from external schema files. Currently supports OpenAPI 3.x (YAML or JSON).
+
+```
+import openapi("schema.yaml")
+```
+
+This generates:
+- **Models** from `components/schemas` (object types with properties)
+- **Scopes** from `paths` (each path+method → scope with config and contract)
+
+Type mapping: `integer` → `int`, `string` → `string`, `boolean` → `bool`, `$ref` → model name. Constraints (`minimum`/`maximum`) are converted to field constraint expressions. Unsupported types (array, float, enum) are skipped with a warning.
+
+Imported scopes have config and contracts populated but no invariants or scenarios — those are hand-authored on top of the imported scaffolds.
+
 ## Available Plugins
 
 ### `use http`

--- a/specs/parse.spec
+++ b/specs/parse.spec
@@ -33,6 +33,17 @@ scope parse_valid {
       name: "AccountAPI"
     }
   }
+
+  # Verifies that import openapi() parses and produces the correct spec name.
+  scenario openapi_import {
+    given {
+      file: "testdata/openapi/import_valid.spec"
+    }
+    then {
+      exit_code: 0
+      name: "ImportTest"
+    }
+  }
 }
 
 # Verifies the parser rejects malformed specs with a non-zero exit code.
@@ -68,10 +79,10 @@ scope parse_invalid {
     }
   }
 
-  # Import with no resolver registered should fail gracefully.
-  scenario import_no_resolver {
+  # Import with unknown adapter should fail.
+  scenario import_unknown_adapter {
     given {
-      file: "testdata/openapi/import_no_resolver.spec"
+      file: "testdata/openapi/import_unknown_adapter.spec"
     }
     then {
       exit_code: 1

--- a/testdata/openapi/import_unknown_adapter.spec
+++ b/testdata/openapi/import_unknown_adapter.spec
@@ -1,0 +1,4 @@
+use http
+spec ImportTest {
+  import protobuf("schema.proto")
+}

--- a/testdata/openapi/import_valid.spec
+++ b/testdata/openapi/import_valid.spec
@@ -1,0 +1,7 @@
+use http
+spec ImportTest {
+  target {
+    base_url: "http://localhost:8080"
+  }
+  import openapi("petstore.yaml")
+}


### PR DESCRIPTION
## Summary

- Wire `openapi.Resolver` into CLI via `defaultImports()` — all commands (parse, generate, verify) support `import openapi("path")`
- Add `examples/openapi/` with petstore.yaml and petstore.spec demonstrating the workflow
- Add `docs/openapi-import.md` — full guide covering type mapping, constraints, limitations
- Add self-verification scenarios: valid OpenAPI import, unknown adapter, bad syntax
- Update README.md with OpenAPI import section and link to docs
- Update CLAUDE.md with import directive documentation and project structure
- Update author skill and API reference with import syntax

Closes #13.

## Test plan

- [x] `specrun parse examples/openapi/petstore.spec` produces correct merged AST
- [x] Self-verification: `openapi_import` scenario passes (exit 0, name "ImportTest")
- [x] Self-verification: `import_unknown_adapter` and `import_bad_syntax` fail correctly
- [x] All existing tests pass — `go test ./... -count=1` green
- [x] `SPECRUN_BIN=./specrun ./specrun verify specs/speclang.spec` — 7/8 scenarios, 2/2 invariants pass (1 pre-existing failure requiring running server)