### PR TITLE
feat(proto): add protobuf schema-to-AST converter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
+require github.com/yoheimuta/go-protoparser/v4 v4.14.2
+
 require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
 github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
+github.com/yoheimuta/go-protoparser/v4 v4.14.2 h1:/P/LlX1CF9NaTWEltGcIZVvNlPbhABuAnBtAWpb3+74=
+github.com/yoheimuta/go-protoparser/v4 v4.14.2/go.mod h1:AHNNnSWnb0UoL4QgHPiOAg2BniQceFscPI5X/BZNHl8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/pkg/proto/models.go
+++ b/pkg/proto/models.go
@@ -1,0 +1,167 @@
+package proto
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/bamsammich/speclang/pkg/parser"
+	pb "github.com/yoheimuta/go-protoparser/v4/parser"
+)
+
+// convertMessages extracts all messages from a proto file and converts
+// them to speclang models. Nested messages are flattened with Parent_Child naming.
+func convertMessages(proto *pb.Proto) []*parser.Model {
+	var models []*parser.Model
+	for _, item := range proto.ProtoBody {
+		switch v := item.(type) {
+		case *pb.Message:
+			models = append(models, flattenMessage("", v)...)
+		}
+	}
+	sort.Slice(models, func(i, j int) bool { return models[i].Name < models[j].Name })
+	return models
+}
+
+// flattenMessage converts a message and its nested messages to models.
+// The prefix is used for collision-safe naming of nested messages.
+func flattenMessage(prefix string, msg *pb.Message) []*parser.Model {
+	name := msg.MessageName
+	if prefix != "" {
+		name = prefix + "_" + msg.MessageName
+	}
+
+	m := &parser.Model{Name: name}
+	var nested []*parser.Model
+
+	for _, item := range msg.MessageBody {
+		switch v := item.(type) {
+		case *pb.Field:
+			field := protoFieldToField(v)
+			if field != nil {
+				m.Fields = append(m.Fields, field)
+			}
+		case *pb.Message:
+			// Nested message — flatten with prefix
+			nested = append(nested, flattenMessage(name, v)...)
+		case *pb.MapField:
+			fmt.Fprintf(os.Stderr, "warning: unsupported map field %q in message %q, skipping\n", v.MapName, name)
+		case *pb.Oneof:
+			fmt.Fprintf(os.Stderr, "warning: unsupported oneof %q in message %q, skipping\n", v.OneofName, name)
+		}
+	}
+
+	// Sort fields by name for deterministic output
+	sort.Slice(m.Fields, func(i, j int) bool { return m.Fields[i].Name < m.Fields[j].Name })
+
+	var models []*parser.Model
+	if len(m.Fields) > 0 {
+		models = append(models, m)
+	}
+	models = append(models, nested...)
+	return models
+}
+
+// protoFieldToField converts a protobuf field to a speclang Field.
+// Returns nil if the type is unsupported.
+func protoFieldToField(f *pb.Field) *parser.Field {
+	if f.IsRepeated {
+		fmt.Fprintf(os.Stderr, "warning: unsupported repeated field %q, skipping\n", f.FieldName)
+		return nil
+	}
+
+	typeExpr, ok := mapProtoType(f.Type)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "warning: unsupported type %q for field %q, skipping\n", f.Type, f.FieldName)
+		return nil
+	}
+
+	if f.IsOptional {
+		typeExpr.Optional = true
+	}
+
+	return &parser.Field{
+		Name: f.FieldName,
+		Type: typeExpr,
+	}
+}
+
+// mapProtoType maps a protobuf type string to a speclang TypeExpr.
+func mapProtoType(typ string) (parser.TypeExpr, bool) {
+	switch typ {
+	// Integer types
+	case "int32", "int64", "sint32", "sint64",
+		"uint32", "uint64",
+		"fixed32", "fixed64", "sfixed32", "sfixed64":
+		return parser.TypeExpr{Name: "int"}, true
+
+	// String
+	case "string":
+		return parser.TypeExpr{Name: "string"}, true
+
+	// Boolean
+	case "bool":
+		return parser.TypeExpr{Name: "bool"}, true
+
+	// Float types — unsupported
+	case "float", "double":
+		return parser.TypeExpr{}, false
+
+	// Bytes — unsupported
+	case "bytes":
+		return parser.TypeExpr{}, false
+
+	default:
+		// Check for well-known types
+		te, ok := mapWellKnownType(typ)
+		if ok {
+			return te, true
+		}
+		// Unsupported well-known types return explicitly false
+		if strings.HasPrefix(typ, "google.protobuf.") {
+			return parser.TypeExpr{}, false
+		}
+		// Assume it's a message reference
+		return parser.TypeExpr{Name: normalizeMessageRef(typ)}, true
+	}
+}
+
+// mapWellKnownType handles google.protobuf.* well-known types.
+func mapWellKnownType(typ string) (parser.TypeExpr, bool) {
+	switch typ {
+	case "google.protobuf.Timestamp", "google.protobuf.Duration",
+		"google.protobuf.FieldMask":
+		return parser.TypeExpr{Name: "string"}, true
+
+	case "google.protobuf.BoolValue":
+		return parser.TypeExpr{Name: "bool", Optional: true}, true
+
+	case "google.protobuf.StringValue":
+		return parser.TypeExpr{Name: "string", Optional: true}, true
+
+	case "google.protobuf.Int32Value", "google.protobuf.Int64Value",
+		"google.protobuf.UInt32Value", "google.protobuf.UInt64Value":
+		return parser.TypeExpr{Name: "int", Optional: true}, true
+
+	case "google.protobuf.FloatValue", "google.protobuf.DoubleValue",
+		"google.protobuf.BytesValue":
+		return parser.TypeExpr{}, false
+
+	case "google.protobuf.Any", "google.protobuf.Struct",
+		"google.protobuf.Value", "google.protobuf.ListValue":
+		return parser.TypeExpr{}, false
+
+	default:
+		return parser.TypeExpr{}, false
+	}
+}
+
+// normalizeMessageRef extracts the simple name from a potentially
+// package-qualified message reference. E.g., "mypackage.User" → "User".
+func normalizeMessageRef(typ string) string {
+	if idx := strings.LastIndex(typ, "."); idx >= 0 {
+		return typ[idx+1:]
+	}
+	return typ
+}

--- a/pkg/proto/proto.go
+++ b/pkg/proto/proto.go
@@ -1,0 +1,49 @@
+// Package proto implements an ImportResolver that converts protobuf
+// schema files (.proto) into speclang AST nodes (models and scopes).
+//
+// It uses go-protoparser for parsing, so no protoc installation is required.
+package proto
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/bamsammich/speclang/pkg/parser"
+	protoparser "github.com/yoheimuta/go-protoparser/v4"
+	pb "github.com/yoheimuta/go-protoparser/v4/parser"
+)
+
+// Resolver implements parser.ImportResolver for protobuf files.
+type Resolver struct{}
+
+// Resolve reads a .proto file and returns speclang models and scopes.
+func (r *Resolver) Resolve(absPath string) ([]*parser.Model, []*parser.Scope, error) {
+	proto, err := parseProtoFile(absPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	models := convertMessages(proto)
+	scopes := convertServices(proto, models)
+
+	return models, scopes, nil
+}
+
+// parseProtoFile reads and parses a .proto file.
+func parseProtoFile(path string) (*pb.Proto, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading proto file: %w", err)
+	}
+	defer f.Close()
+
+	proto, err := protoparser.Parse(
+		f,
+		protoparser.WithPermissive(true),
+		protoparser.WithFilename(path),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("parsing proto file: %w", err)
+	}
+	return proto, nil
+}

--- a/pkg/proto/proto_test.go
+++ b/pkg/proto/proto_test.go
@@ -1,0 +1,314 @@
+package proto
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/bamsammich/speclang/pkg/parser"
+)
+
+func testdataPath(name string) string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(file), "..", "..", "testdata", "proto", name)
+}
+
+func TestResolve_User(t *testing.T) {
+	r := &Resolver{}
+	models, scopes, err := r.Resolve(testdataPath("user.proto"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 4 messages: CreateUserRequest, CreateUserResponse, GetUserRequest, GetUserResponse, User
+	// But User is referenced as a message type in responses, not as a field with unsupported type
+	if len(models) < 4 {
+		t.Fatalf("expected at least 4 models, got %d", len(models))
+	}
+
+	// 2 unary RPCs
+	if len(scopes) != 2 {
+		t.Fatalf("expected 2 scopes, got %d", len(scopes))
+	}
+}
+
+func TestConvertMessages_User(t *testing.T) {
+	proto, err := parseProtoFile(testdataPath("user.proto"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	models := convertMessages(proto)
+
+	// Find User model
+	var user *parser.Model
+	for _, m := range models {
+		if m.Name == "User" {
+			user = m
+		}
+	}
+	if user == nil {
+		t.Fatal("User model not found")
+	}
+
+	// User has 4 fields: id (int), name (string), email (string), phone (string?)
+	if len(user.Fields) != 4 {
+		t.Fatalf("expected 4 fields in User, got %d", len(user.Fields))
+	}
+
+	// Fields sorted: email, id, name, phone
+	assertField(t, user.Fields[0], "email", "string", false)
+	assertField(t, user.Fields[1], "id", "int", false)
+	assertField(t, user.Fields[2], "name", "string", false)
+	assertField(t, user.Fields[3], "phone", "string", true) // optional
+}
+
+func TestConvertMessages_Nested(t *testing.T) {
+	proto, err := parseProtoFile(testdataPath("nested.proto"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	models := convertMessages(proto)
+
+	// SearchResponse has a repeated field (skipped) and total_count
+	// SearchResponse_Result is the nested message, flattened
+	var result *parser.Model
+	var search *parser.Model
+	for _, m := range models {
+		switch m.Name {
+		case "SearchResponse_Result":
+			result = m
+		case "SearchResponse":
+			search = m
+		}
+	}
+
+	if result == nil {
+		t.Fatal("SearchResponse_Result model not found")
+	}
+	if len(result.Fields) != 3 {
+		t.Fatalf("expected 3 fields in SearchResponse_Result, got %d", len(result.Fields))
+	}
+
+	if search == nil {
+		t.Fatal("SearchResponse model not found")
+	}
+	// SearchResponse.results is repeated (skipped), only total_count remains
+	if len(search.Fields) != 1 {
+		t.Fatalf("expected 1 field in SearchResponse (repeated skipped), got %d", len(search.Fields))
+	}
+	if search.Fields[0].Name != "total_count" {
+		t.Errorf("expected field 'total_count', got %q", search.Fields[0].Name)
+	}
+}
+
+func TestConvertMessages_Unsupported(t *testing.T) {
+	proto, err := parseProtoFile(testdataPath("unsupported.proto"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	models := convertMessages(proto)
+
+	// MixedTypes: name (string) + count (int) survive; double, float, bytes, repeated, map are skipped
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+
+	m := models[0]
+	if m.Name != "MixedTypes" {
+		t.Fatalf("expected model MixedTypes, got %q", m.Name)
+	}
+
+	if len(m.Fields) != 2 {
+		t.Fatalf("expected 2 supported fields, got %d", len(m.Fields))
+	}
+
+	assertField(t, m.Fields[0], "count", "int", false)
+	assertField(t, m.Fields[1], "name", "string", false)
+}
+
+func TestConvertMessages_Empty(t *testing.T) {
+	proto, err := parseProtoFile(testdataPath("empty.proto"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	models := convertMessages(proto)
+	if len(models) != 0 {
+		t.Errorf("expected 0 models, got %d", len(models))
+	}
+}
+
+func TestConvertServices_User(t *testing.T) {
+	proto, err := parseProtoFile(testdataPath("user.proto"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	models := convertMessages(proto)
+	scopes := convertServices(proto, models)
+
+	if len(scopes) != 2 {
+		t.Fatalf("expected 2 scopes, got %d", len(scopes))
+	}
+
+	// Sorted: CreateUser, GetUser
+	assertScopeName(t, scopes, 0, "CreateUser")
+	assertScopeName(t, scopes, 1, "GetUser")
+
+	// CreateUser scope
+	cu := scopes[0]
+	assertConfigValue(t, cu, "service", "UserService")
+	assertConfigValue(t, cu, "method", "CreateUser")
+
+	if cu.Contract == nil {
+		t.Fatal("CreateUser should have a contract")
+	}
+	if len(cu.Contract.Input) == 0 {
+		t.Error("CreateUser should have contract input fields")
+	}
+	if len(cu.Contract.Output) == 0 {
+		t.Error("CreateUser should have contract output fields")
+	}
+}
+
+func TestConvertServices_Streaming(t *testing.T) {
+	proto, err := parseProtoFile(testdataPath("streaming.proto"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	models := convertMessages(proto)
+	scopes := convertServices(proto, models)
+
+	// Only SendEvent is unary; the other 3 are streaming and should be skipped
+	if len(scopes) != 1 {
+		t.Fatalf("expected 1 scope (unary only), got %d", len(scopes))
+	}
+	if scopes[0].Name != "SendEvent" {
+		t.Errorf("expected scope 'SendEvent', got %q", scopes[0].Name)
+	}
+}
+
+func TestConvertMessages_MessageRef(t *testing.T) {
+	proto, err := parseProtoFile(testdataPath("user.proto"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	models := convertMessages(proto)
+
+	// CreateUserResponse has a 'user' field of type User (message reference)
+	var resp *parser.Model
+	for _, m := range models {
+		if m.Name == "CreateUserResponse" {
+			resp = m
+		}
+	}
+	if resp == nil {
+		t.Fatal("CreateUserResponse model not found")
+	}
+
+	var userField *parser.Field
+	for _, f := range resp.Fields {
+		if f.Name == "user" {
+			userField = f
+		}
+	}
+	if userField == nil {
+		t.Fatal("user field not found in CreateUserResponse")
+	}
+	if userField.Type.Name != "User" {
+		t.Errorf("expected type 'User', got %q", userField.Type.Name)
+	}
+}
+
+func TestMapProtoType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+		ok    bool
+	}{
+		{"int32", "int", true},
+		{"int64", "int", true},
+		{"uint32", "int", true},
+		{"uint64", "int", true},
+		{"sint32", "int", true},
+		{"sint64", "int", true},
+		{"fixed32", "int", true},
+		{"fixed64", "int", true},
+		{"sfixed32", "int", true},
+		{"sfixed64", "int", true},
+		{"string", "string", true},
+		{"bool", "bool", true},
+		{"float", "", false},
+		{"double", "", false},
+		{"bytes", "", false},
+		{"MyMessage", "MyMessage", true},
+		{"package.MyMessage", "MyMessage", true},
+		{"google.protobuf.Timestamp", "string", true},
+		{"google.protobuf.BoolValue", "bool", true},
+		{"google.protobuf.StringValue", "string", true},
+		{"google.protobuf.Int32Value", "int", true},
+		{"google.protobuf.Any", "", false},
+	}
+
+	for _, tt := range tests {
+		got, ok := mapProtoType(tt.input)
+		if ok != tt.ok {
+			t.Errorf("mapProtoType(%q): ok = %v, want %v", tt.input, ok, tt.ok)
+			continue
+		}
+		if ok && got.Name != tt.want {
+			t.Errorf("mapProtoType(%q) = %q, want %q", tt.input, got.Name, tt.want)
+		}
+	}
+}
+
+func TestParseProtoFile_Invalid(t *testing.T) {
+	_, err := parseProtoFile("/nonexistent/file.proto")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+// --- helpers ---
+
+func assertField(t *testing.T, f *parser.Field, name, typeName string, optional bool) {
+	t.Helper()
+	if f.Name != name {
+		t.Errorf("field.Name = %q, want %q", f.Name, name)
+	}
+	if f.Type.Name != typeName {
+		t.Errorf("field %q: Type.Name = %q, want %q", name, f.Type.Name, typeName)
+	}
+	if f.Type.Optional != optional {
+		t.Errorf("field %q: Optional = %v, want %v", name, f.Type.Optional, optional)
+	}
+}
+
+func assertScopeName(t *testing.T, scopes []*parser.Scope, idx int, name string) {
+	t.Helper()
+	if scopes[idx].Name != name {
+		t.Errorf("scopes[%d].Name = %q, want %q", idx, scopes[idx].Name, name)
+	}
+}
+
+func assertConfigValue(t *testing.T, scope *parser.Scope, key, expected string) {
+	t.Helper()
+	expr, ok := scope.Config[key]
+	if !ok {
+		t.Errorf("scope %q: config key %q not found", scope.Name, key)
+		return
+	}
+	lit, ok := expr.(parser.LiteralString)
+	if !ok {
+		t.Errorf("scope %q: config %q is not a LiteralString", scope.Name, key)
+		return
+	}
+	if lit.Value != expected {
+		t.Errorf("scope %q: config %q = %q, want %q", scope.Name, key, lit.Value, expected)
+	}
+}

--- a/pkg/proto/scopes.go
+++ b/pkg/proto/scopes.go
@@ -1,0 +1,91 @@
+package proto
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/bamsammich/speclang/pkg/parser"
+	pb "github.com/yoheimuta/go-protoparser/v4/parser"
+)
+
+// convertServices extracts RPC methods from proto services and converts
+// them to speclang scopes. Only unary RPCs are supported.
+func convertServices(proto *pb.Proto, models []*parser.Model) []*parser.Scope {
+	modelMap := make(map[string]*parser.Model, len(models))
+	for _, m := range models {
+		modelMap[m.Name] = m
+	}
+
+	var scopes []*parser.Scope
+	for _, item := range proto.ProtoBody {
+		svc, ok := item.(*pb.Service)
+		if !ok {
+			continue
+		}
+		for _, body := range svc.ServiceBody {
+			rpc, ok := body.(*pb.RPC)
+			if !ok {
+				continue
+			}
+			scope := rpcToScope(svc.ServiceName, rpc, modelMap)
+			if scope != nil {
+				scopes = append(scopes, scope)
+			}
+		}
+	}
+	sort.Slice(scopes, func(i, j int) bool { return scopes[i].Name < scopes[j].Name })
+	return scopes
+}
+
+// rpcToScope converts a single RPC method to a speclang Scope.
+// Returns nil for streaming RPCs.
+func rpcToScope(serviceName string, rpc *pb.RPC, models map[string]*parser.Model) *parser.Scope {
+	// Skip streaming RPCs
+	if rpc.RPCRequest.IsStream || rpc.RPCResponse.IsStream {
+		fmt.Fprintf(os.Stderr, "warning: skipping streaming RPC %s.%s\n", serviceName, rpc.RPCName)
+		return nil
+	}
+
+	scope := &parser.Scope{
+		Name: rpc.RPCName,
+		Config: map[string]parser.Expr{
+			"service": parser.LiteralString{Value: serviceName},
+			"method":  parser.LiteralString{Value: rpc.RPCName},
+		},
+	}
+
+	contract := &parser.Contract{}
+
+	// Request → contract input
+	reqType := normalizeMessageRef(rpc.RPCRequest.MessageType)
+	if reqType != "Empty" && reqType != "google.protobuf.Empty" {
+		if m, ok := models[reqType]; ok {
+			contract.Input = copyFields(m.Fields)
+		}
+	}
+
+	// Response → contract output
+	respType := normalizeMessageRef(rpc.RPCResponse.MessageType)
+	if respType != "Empty" && respType != "google.protobuf.Empty" {
+		if m, ok := models[respType]; ok {
+			contract.Output = copyFields(m.Fields)
+		}
+	}
+
+	if contract.Input != nil || contract.Output != nil {
+		scope.Contract = contract
+	}
+
+	return scope
+}
+
+// copyFields creates a shallow copy of a field slice for contract use.
+func copyFields(fields []*parser.Field) []*parser.Field {
+	if len(fields) == 0 {
+		return nil
+	}
+	out := make([]*parser.Field, len(fields))
+	copy(out, fields)
+	return out
+}

--- a/testdata/proto/empty.proto
+++ b/testdata/proto/empty.proto
@@ -1,0 +1,1 @@
+syntax = "proto3";

--- a/testdata/proto/nested.proto
+++ b/testdata/proto/nested.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+message SearchResponse {
+  message Result {
+    string url = 1;
+    string title = 2;
+    int32 rank = 3;
+  }
+
+  repeated Result results = 1;
+  int32 total_count = 2;
+}

--- a/testdata/proto/streaming.proto
+++ b/testdata/proto/streaming.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+message Event {
+  string id = 1;
+  string payload = 2;
+}
+
+message Ack {
+  bool ok = 1;
+}
+
+service EventService {
+  rpc SendEvent(Event) returns (Ack);
+  rpc StreamEvents(Event) returns (stream Event);
+  rpc IngestEvents(stream Event) returns (Ack);
+  rpc BiDiStream(stream Event) returns (stream Event);
+}

--- a/testdata/proto/unsupported.proto
+++ b/testdata/proto/unsupported.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+message MixedTypes {
+  string name = 1;
+  int32 count = 2;
+  double price = 3;
+  float rating = 4;
+  bytes data = 5;
+  repeated string tags = 6;
+  map<string, int32> scores = 7;
+}
+
+enum Status {
+  UNKNOWN = 0;
+  ACTIVE = 1;
+  INACTIVE = 2;
+}

--- a/testdata/proto/user.proto
+++ b/testdata/proto/user.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package userapi;
+
+message User {
+  int64 id = 1;
+  string name = 2;
+  string email = 3;
+  optional string phone = 4;
+}
+
+message CreateUserRequest {
+  string name = 1;
+  string email = 2;
+}
+
+message CreateUserResponse {
+  User user = 1;
+  bool success = 2;
+}
+
+message GetUserRequest {
+  int64 id = 1;
+}
+
+message GetUserResponse {
+  User user = 1;
+}
+
+service UserService {
+  rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+  rpc GetUser(GetUserRequest) returns (GetUserResponse);
+}


### PR DESCRIPTION
## Summary

- New `pkg/proto/` package implementing `parser.ImportResolver` for protobuf files
- Uses [go-protoparser](https://github.com/yoheimuta/go-protoparser) (zero transitive deps, no protoc required)
- Converts `message` definitions to speclang models (scalar type mapping, message refs, nested flattening)
- Converts unary `rpc` methods to scopes with service/method config and contracts
- Handles well-known types (Timestamp→string, wrappers→optional)
- Skips streaming RPCs, unsupported types (float, bytes, repeated, map, oneof, enum) with warnings

Closes #19.

## Test plan

- [x] 10 unit tests: user messages, nested messages, unsupported types, empty, services, streaming, message refs, type mapping, invalid file
- [x] Test fixtures in `testdata/proto/` (user, nested, streaming, unsupported, empty)
- [x] All existing tests pass — `go test ./... -count=1` green