### PR TITLE
feat: wire protobuf import end-to-end with docs and examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ spec <Name> {
 
   include "<path>"                   # spec-body include
   import openapi("<path>")           # import models/scopes from OpenAPI schema
+  import proto("<path>")             # import models/scopes from protobuf schema
 
   locators {                         # UI-mode only
     <name>: [<css-selector>]
@@ -256,6 +257,10 @@ speclang/
 │   │   ├── document.go   # OpenAPI doc loading via kin-openapi
 │   │   ├── models.go     # schema → Model conversion
 │   │   └── scopes.go     # path → Scope conversion
+│   ├── proto/            # Protobuf import resolver
+│   │   ├── proto.go      # Resolver implementing ImportResolver
+│   │   ├── models.go     # message → Model conversion
+│   │   └── scopes.go     # service/RPC → Scope conversion
 │   └── plugin/           # plugin spec loading
 │       └── plugin.go
 ├── plugins/
@@ -270,6 +275,9 @@ speclang/
 │   ├── openapi/          # OpenAPI import example
 │   │   ├── petstore.yaml # sample OpenAPI 3.0 spec
 │   │   └── petstore.spec # spec importing from OpenAPI schema
+│   ├── proto/            # Protobuf import example
+│   │   ├── user.proto    # sample protobuf service definition
+│   │   └── user.spec     # spec importing from protobuf schema
 │   └── server/           # trivial Go HTTP server to test against
 │       └── main.go
 ├── specs/                # self-verification specs (speclang verifying itself)

--- a/README.md
+++ b/README.md
@@ -203,6 +203,18 @@ This generates models from `components/schemas` and scopes from `paths`, letting
 
 See [docs/openapi-import.md](docs/openapi-import.md) for the full guide, type mapping, and limitations.
 
+## Protobuf Import
+
+Import models and scopes from protobuf service definitions:
+
+```
+import proto("service.proto")
+```
+
+This generates models from `message` definitions and scopes from unary `rpc` methods.
+
+See [docs/protobuf-import.md](docs/protobuf-import.md) for details.
+
 ## Plugins
 
 speclang uses a plugin architecture for interacting with different systems:

--- a/cmd/specrun/main.go
+++ b/cmd/specrun/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bamsammich/speclang/pkg/generator"
 	"github.com/bamsammich/speclang/pkg/openapi"
 	"github.com/bamsammich/speclang/pkg/parser"
+	protoResolver "github.com/bamsammich/speclang/pkg/proto"
 	"github.com/bamsammich/speclang/pkg/runner"
 )
 
@@ -300,5 +301,6 @@ func resolveExprToString(expr parser.Expr) string {
 func defaultImports() parser.ImportRegistry {
 	return parser.ImportRegistry{
 		"openapi": &openapi.Resolver{},
+		"proto":   &protoResolver.Resolver{},
 	}
 }

--- a/docs/protobuf-import.md
+++ b/docs/protobuf-import.md
@@ -1,0 +1,131 @@
+# Working with Protobuf Schemas in Speclang
+
+Speclang can import models and scope scaffolds directly from `.proto` files. This lets you start from an existing protobuf service definition and layer verification properties on top.
+
+## Quick Start
+
+Given a protobuf file `api.proto`:
+
+```protobuf
+syntax = "proto3";
+
+message User {
+  int64 id = 1;
+  string name = 2;
+  optional string email = 3;
+}
+
+message CreateUserRequest {
+  string name = 1;
+  string email = 2;
+}
+
+message CreateUserResponse {
+  User user = 1;
+  bool success = 2;
+}
+
+service UserService {
+  rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+}
+```
+
+Write a speclang spec that imports it:
+
+```
+use http
+
+spec UserAPI {
+  target {
+    base_url: env(APP_URL, "http://localhost:8080")
+  }
+
+  import proto("api.proto")
+}
+```
+
+Then verify:
+
+```bash
+specrun verify userapi.spec
+```
+
+## What Gets Imported
+
+### Models (from `message` definitions)
+
+Each protobuf message becomes a speclang model.
+
+| Protobuf type | Speclang type | Notes |
+|---|---|---|
+| `int32`, `int64`, `sint32`, `sint64` | `int` | All integer types collapse to `int` |
+| `uint32`, `uint64`, `fixed32`, `fixed64` | `int` | Loss of sign/size distinction |
+| `sfixed32`, `sfixed64` | `int` | |
+| `string` | `string` | Direct |
+| `bool` | `bool` | Direct |
+| message reference | model name | e.g., `User` |
+| `optional T` | `T?` | Optional field |
+| `float`, `double` | — | Skipped with warning |
+| `bytes` | — | Skipped with warning |
+| `repeated T` | — | Skipped with warning |
+| `map<K,V>` | — | Skipped with warning |
+| `oneof` | — | Skipped with warning |
+| `enum` | — | Skipped with warning |
+
+**Note**: No constraints are generated from protobuf fields — protobuf does not encode numeric ranges natively.
+
+### Nested Messages
+
+Nested messages are flattened to top-level models with `Parent_Child` naming:
+
+```protobuf
+message SearchResponse {
+  message Result {
+    string url = 1;
+  }
+}
+```
+
+Produces models `SearchResponse` and `SearchResponse_Result`.
+
+### Well-Known Types
+
+| Type | Mapping |
+|---|---|
+| `google.protobuf.Timestamp` | `string` |
+| `google.protobuf.Duration` | `string` |
+| `google.protobuf.Empty` | omit (empty contract side) |
+| `google.protobuf.BoolValue` | `bool?` |
+| `google.protobuf.StringValue` | `string?` |
+| `google.protobuf.Int32Value` / `Int64Value` | `int?` |
+| `google.protobuf.Any` / `Struct` / `Value` | Skipped |
+
+### Scopes (from `service` definitions)
+
+Each **unary** RPC method becomes a scope:
+
+- **Scope name**: RPC method name (e.g., `CreateUser`)
+- **Config**: `service` and `method` populated from the service/RPC names
+- **Contract input**: Fields from the request message
+- **Contract output**: Fields from the response message
+- **Streaming RPCs**: Skipped with warning (speclang contracts are strictly request → response)
+- **No invariants or scenarios**: Those are hand-authored
+
+## Limitations
+
+- **No constraints**: Protobuf doesn't encode min/max. All fields are unconstrained.
+- **No float/double**: Speclang has no float type (#21).
+- **No repeated/array**: Speclang has no array type (#21).
+- **No map**: Speclang has no map type (#21).
+- **No oneof/enum**: No union or enum types.
+- **No bytes**: No binary type.
+- **Single-file only**: Cross-file `import` in proto files is not resolved.
+- **Streaming RPCs**: Cannot be expressed in speclang's contract model.
+
+## Example
+
+See [`examples/proto/`](../examples/proto/) for a complete example importing a User service.
+
+## Technical Details
+
+The import uses [go-protoparser](https://github.com/yoheimuta/go-protoparser) for `.proto` file parsing (zero external dependencies, no `protoc` required). The converter produces standard speclang AST nodes, making imported schemas indistinguishable from hand-written ones to the generator, runner, and adapter.

--- a/examples/proto/user.proto
+++ b/examples/proto/user.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package userapi;
+
+message User {
+  int64 id = 1;
+  string name = 2;
+  string email = 3;
+  optional string phone = 4;
+}
+
+message CreateUserRequest {
+  string name = 1;
+  string email = 2;
+}
+
+message CreateUserResponse {
+  User user = 1;
+  bool success = 2;
+}
+
+message GetUserRequest {
+  int64 id = 1;
+}
+
+message GetUserResponse {
+  User user = 1;
+}
+
+service UserService {
+  rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+  rpc GetUser(GetUserRequest) returns (GetUserResponse);
+}

--- a/examples/proto/user.spec
+++ b/examples/proto/user.spec
@@ -1,0 +1,23 @@
+use http
+
+spec UserAPI {
+  description: "User service API imported from protobuf schema"
+
+  target {
+    base_url: env(APP_URL, "http://localhost:8080")
+  }
+
+  # Import models and scope scaffolds from protobuf schema.
+  import proto("user.proto")
+
+  # The import generates:
+  #   model User { email: string  id: int  name: string  phone: string? }
+  #   model CreateUserRequest { email: string  name: string }
+  #   model CreateUserResponse { success: bool  user: User }
+  #   model GetUserRequest { id: int }
+  #   model GetUserResponse { user: User }
+  #   scope CreateUser { config { service: "UserService"  method: "CreateUser" } contract { ... } }
+  #   scope GetUser { config { service: "UserService"  method: "GetUser" } contract { ... } }
+  #
+  # Add invariants and scenarios on top of the imported scaffolds.
+}

--- a/skills/author/references/api_reference.md
+++ b/skills/author/references/api_reference.md
@@ -152,19 +152,25 @@ include "scopes/transfer.spec"
 
 ## Import Directive
 
-Import models and scopes from external schema files. Currently supports OpenAPI 3.x (YAML or JSON).
+Import models and scopes from external schema files. Supports OpenAPI 3.x and protobuf.
+
+### OpenAPI
 
 ```
 import openapi("schema.yaml")
 ```
 
-This generates:
-- **Models** from `components/schemas` (object types with properties)
-- **Scopes** from `paths` (each path+method → scope with config and contract)
+Generates models from `components/schemas` and scopes from `paths`. Type mapping: `integer` → `int`, `string` → `string`, `boolean` → `bool`, `$ref` → model name. Constraints (`minimum`/`maximum`) are converted to field constraint expressions.
 
-Type mapping: `integer` → `int`, `string` → `string`, `boolean` → `bool`, `$ref` → model name. Constraints (`minimum`/`maximum`) are converted to field constraint expressions. Unsupported types (array, float, enum) are skipped with a warning.
+### Protobuf
 
-Imported scopes have config and contracts populated but no invariants or scenarios — those are hand-authored on top of the imported scaffolds.
+```
+import proto("service.proto")
+```
+
+Generates models from `message` definitions and scopes from unary `rpc` methods. Type mapping: all integer types → `int`, `string` → `string`, `bool` → `bool`, message reference → model name.
+
+Unsupported types (array, float, enum, bytes, map) are skipped with a warning in both importers. Imported scopes have config and contracts populated but no invariants or scenarios — those are hand-authored.
 
 ## Available Plugins
 

--- a/specs/parse.spec
+++ b/specs/parse.spec
@@ -44,6 +44,17 @@ scope parse_valid {
       name: "ImportTest"
     }
   }
+
+  # Verifies that import proto() parses and produces the correct spec name.
+  scenario proto_import {
+    given {
+      file: "testdata/proto/import_valid.spec"
+    }
+    then {
+      exit_code: 0
+      name: "ProtoImportTest"
+    }
+  }
 }
 
 # Verifies the parser rejects malformed specs with a non-zero exit code.

--- a/testdata/proto/import_valid.spec
+++ b/testdata/proto/import_valid.spec
@@ -1,0 +1,7 @@
+use http
+spec ProtoImportTest {
+  target {
+    base_url: "http://localhost:8080"
+  }
+  import proto("user.proto")
+}


### PR DESCRIPTION
## Summary

- Register `proto.Resolver` in CLI via `defaultImports()` — `import proto("path")` works in all commands
- Add `examples/proto/` with user.proto and user.spec demonstrating the workflow
- Add `docs/protobuf-import.md` — full guide with type mapping, well-known types, limitations
- Add self-verification scenario for proto import parsing
- Update README.md with Protobuf Import section
- Update CLAUDE.md with proto import syntax and project structure
- Update API reference with proto import documentation

Closes #20.

## Test plan

- [x] `specrun parse examples/proto/user.spec` produces correct merged AST
- [x] Self-verification: `proto_import` scenario passes (exit 0, name "ProtoImportTest")
- [x] All tests pass — `go test ./... -count=1` green
- [x] `SPECRUN_BIN=./specrun ./specrun verify specs/speclang.spec` — 8/9 scenarios, 2/2 invariants pass