### PR TITLE
fix: update module path to v2 for Go module compatibility

### DIFF
--- a/cmd/specrun/main.go
+++ b/cmd/specrun/main.go
@@ -8,12 +8,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bamsammich/speclang/pkg/adapter"
-	"github.com/bamsammich/speclang/pkg/generator"
-	"github.com/bamsammich/speclang/pkg/openapi"
-	"github.com/bamsammich/speclang/pkg/parser"
-	protoResolver "github.com/bamsammich/speclang/pkg/proto"
-	"github.com/bamsammich/speclang/pkg/runner"
+	"github.com/bamsammich/speclang/v2/pkg/adapter"
+	"github.com/bamsammich/speclang/v2/pkg/generator"
+	"github.com/bamsammich/speclang/v2/pkg/openapi"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
+	protoResolver "github.com/bamsammich/speclang/v2/pkg/proto"
+	"github.com/bamsammich/speclang/v2/pkg/runner"
 	playwright "github.com/playwright-community/playwright-go"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bamsammich/speclang
+module github.com/bamsammich/speclang/v2
 
 go 1.26.1
 

--- a/pkg/adapter/playwright_test.go
+++ b/pkg/adapter/playwright_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/bamsammich/speclang/pkg/adapter"
+	"github.com/bamsammich/speclang/v2/pkg/adapter"
 	pw "github.com/playwright-community/playwright-go"
 )
 

--- a/pkg/generator/array_test.go
+++ b/pkg/generator/array_test.go
@@ -3,7 +3,7 @@ package generator
 import (
 	"testing"
 
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 )
 
 func TestGenerateArray(t *testing.T) {

--- a/pkg/generator/float_test.go
+++ b/pkg/generator/float_test.go
@@ -5,7 +5,7 @@ import (
 	"math/rand/v2"
 	"testing"
 
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 )
 
 func TestGenerateFloat(t *testing.T) {

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -8,7 +8,7 @@ import (
 	"math/rand/v2" //nolint:gosec // intentional use of math/rand for reproducible test generation
 	"strings"
 
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 )
 
 // Generator produces random valid inputs from a contract and model definitions.

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -3,7 +3,7 @@ package generator
 import (
 	"testing"
 
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 )
 
 func transferContract() (*parser.Contract, []*parser.Model) {

--- a/pkg/generator/shrink.go
+++ b/pkg/generator/shrink.go
@@ -3,7 +3,7 @@ package generator
 import (
 	"encoding/base64"
 
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 )
 
 // Shrink attempts to find a minimal counterexample by shrinking each field

--- a/pkg/openapi/models.go
+++ b/pkg/openapi/models.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 )
 
 // convertSchemas converts OpenAPI component schemas to speclang models.

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -6,7 +6,7 @@
 package openapi
 
 import (
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 )
 
 // Resolver implements parser.ImportResolver for OpenAPI 3.x specs.

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 )
 
 func testdataPath(name string) string {

--- a/pkg/openapi/scopes.go
+++ b/pkg/openapi/scopes.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 )
 
 // convertPaths converts OpenAPI paths to speclang scopes.

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -3,7 +3,7 @@ package parser_test
 import (
 	"testing"
 
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 )
 
 func TestParseTransferSpec(t *testing.T) {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"fmt"
 
-	"github.com/bamsammich/speclang/pkg/adapter"
+	"github.com/bamsammich/speclang/v2/pkg/adapter"
 )
 
 // Registry maps plugin names to their adapters.

--- a/pkg/proto/models.go
+++ b/pkg/proto/models.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 	pb "github.com/yoheimuta/go-protoparser/v4/parser"
 )
 

--- a/pkg/proto/proto.go
+++ b/pkg/proto/proto.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 	protoparser "github.com/yoheimuta/go-protoparser/v4"
 	pb "github.com/yoheimuta/go-protoparser/v4/parser"
 )

--- a/pkg/proto/proto_test.go
+++ b/pkg/proto/proto_test.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 )
 
 func testdataPath(name string) string {

--- a/pkg/proto/scopes.go
+++ b/pkg/proto/scopes.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 	pb "github.com/yoheimuta/go-protoparser/v4/parser"
 )
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bamsammich/speclang/pkg/adapter"
-	"github.com/bamsammich/speclang/pkg/generator"
-	"github.com/bamsammich/speclang/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/adapter"
+	"github.com/bamsammich/speclang/v2/pkg/generator"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
 )
 
 // Result captures the outcome of a verification run.

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -6,9 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/bamsammich/speclang/pkg/adapter"
-	"github.com/bamsammich/speclang/pkg/parser"
-	"github.com/bamsammich/speclang/pkg/runner"
+	"github.com/bamsammich/speclang/v2/pkg/adapter"
+	"github.com/bamsammich/speclang/v2/pkg/parser"
+	"github.com/bamsammich/speclang/v2/pkg/runner"
 )
 
 func transferHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Update `go.mod` module path from `github.com/bamsammich/speclang` to `github.com/bamsammich/speclang/v2`
- Update all internal import paths to use `/v2/` prefix
- Required for `go install github.com/bamsammich/speclang/v2/cmd/specrun@v2.0.0` to work

Go modules require v2+ packages to have the `/v2` suffix in the module path. Without this, `go install` can't resolve the `v2.0.0` tag.

After merging, the `v2.0.0` release tag needs to be moved to the new HEAD.

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./... -count=1` — all 7 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)