### PR TITLE
feat(specs): add parser and validator rejection scenarios

### DIFF
--- a/specs/parse.spec
+++ b/specs/parse.spec
@@ -122,4 +122,171 @@ scope parse_invalid {
       exit_code: 1
     }
   }
+
+  # Scope without 'use <plugin>' should fail.
+  scenario missing_use_directive {
+    given {
+      file: "testdata/self/invalid_missing_use.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # Multiple 'use' directives in same scope should fail.
+  scenario multiple_use_directives {
+    given {
+      file: "testdata/self/invalid_multiple_use.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # 'use' at spec level (outside scope) should fail.
+  scenario use_at_spec_level {
+    given {
+      file: "testdata/self/invalid_use_at_spec_level.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # Unknown token in spec body should fail.
+  scenario unknown_token_in_spec {
+    given {
+      file: "testdata/self/invalid_unknown_token.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # Unexpected keyword inside contract block should fail.
+  scenario malformed_contract {
+    given {
+      file: "testdata/self/invalid_malformed_contract.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # Unexpected token inside then block should fail.
+  scenario malformed_then {
+    given {
+      file: "testdata/self/invalid_malformed_then.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # Unterminated string literal should fail at lex time.
+  scenario unterminated_string {
+    given {
+      file: "testdata/self/invalid_unterminated_string.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # Single '&' (incomplete operator) should fail at lex time.
+  scenario incomplete_operator {
+    given {
+      file: "testdata/self/invalid_single_ampersand.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # Duplicate model names across includes should fail.
+  scenario duplicate_model_include {
+    given {
+      file: "testdata/include/duplicate/root.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # Duplicate scope names across includes should fail.
+  scenario duplicate_scope_include {
+    given {
+      file: "testdata/include/duplicate_scope/root.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+}
+
+# Verifies the validator rejects semantically invalid specs with a non-zero exit code.
+scope validate_invalid {
+  use process
+  config {
+    args: "parse"
+  }
+
+  contract {
+    input {
+      file: string
+    }
+    output {
+      exit_code: int
+    }
+  }
+
+  # Unknown type in model field should fail validation.
+  scenario unknown_type {
+    given {
+      file: "testdata/self/invalid_unknown_type.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # String literal for int field should fail validation.
+  scenario type_mismatch_in_given {
+    given {
+      file: "testdata/self/invalid_type_mismatch.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # Null for non-optional field should fail validation.
+  scenario null_non_optional {
+    given {
+      file: "testdata/self/invalid_null_non_optional.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # Missing required field in given block should fail validation.
+  scenario missing_required_field {
+    given {
+      file: "testdata/self/invalid_missing_required_field.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+
+  # Then target not in contract output should fail validation.
+  scenario then_unknown_output {
+    given {
+      file: "testdata/self/invalid_then_unknown_field.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
 }

--- a/testdata/self/invalid_malformed_contract.spec
+++ b/testdata/self/invalid_malformed_contract.spec
@@ -1,0 +1,8 @@
+spec Bad {
+  scope broken {
+    use http
+    contract {
+      scenario wrong {}
+    }
+  }
+}

--- a/testdata/self/invalid_malformed_then.spec
+++ b/testdata/self/invalid_malformed_then.spec
@@ -1,0 +1,15 @@
+spec Bad {
+  scope broken {
+    use http
+    contract {
+      input { x: int }
+      output { y: int }
+    }
+    scenario test {
+      given { x: 1 }
+      then {
+        scenario nested {}
+      }
+    }
+  }
+}

--- a/testdata/self/invalid_missing_required_field.spec
+++ b/testdata/self/invalid_missing_required_field.spec
@@ -1,0 +1,22 @@
+spec Bad {
+  scope broken {
+    use http
+    contract {
+      input {
+        from: string
+        to: string
+      }
+      output {
+        result: int
+      }
+    }
+    scenario smoke {
+      given {
+        from: "alice"
+      }
+      then {
+        result: 0
+      }
+    }
+  }
+}

--- a/testdata/self/invalid_missing_use.spec
+++ b/testdata/self/invalid_missing_use.spec
@@ -1,0 +1,12 @@
+spec Bad {
+  scope missing_use {
+    contract {
+      input {
+        x: int
+      }
+      output {
+        y: int
+      }
+    }
+  }
+}

--- a/testdata/self/invalid_multiple_use.spec
+++ b/testdata/self/invalid_multiple_use.spec
@@ -1,0 +1,6 @@
+spec Bad {
+  scope double_use {
+    use http
+    use process
+  }
+}

--- a/testdata/self/invalid_null_non_optional.spec
+++ b/testdata/self/invalid_null_non_optional.spec
@@ -1,0 +1,21 @@
+spec Bad {
+  scope broken {
+    use http
+    contract {
+      input {
+        name: string
+      }
+      output {
+        result: int
+      }
+    }
+    scenario smoke {
+      given {
+        name: null
+      }
+      then {
+        result: 0
+      }
+    }
+  }
+}

--- a/testdata/self/invalid_single_ampersand.spec
+++ b/testdata/self/invalid_single_ampersand.spec
@@ -1,0 +1,12 @@
+spec Bad {
+  scope broken {
+    use http
+    contract {
+      input { x: int }
+      output { y: int }
+    }
+    invariant bad_op {
+      x > 0 & x < 10
+    }
+  }
+}

--- a/testdata/self/invalid_then_unknown_field.spec
+++ b/testdata/self/invalid_then_unknown_field.spec
@@ -1,0 +1,21 @@
+spec Bad {
+  scope broken {
+    use http
+    contract {
+      input {
+        x: int
+      }
+      output {
+        result: int
+      }
+    }
+    scenario smoke {
+      given {
+        x: 1
+      }
+      then {
+        typo_field: 0
+      }
+    }
+  }
+}

--- a/testdata/self/invalid_type_mismatch.spec
+++ b/testdata/self/invalid_type_mismatch.spec
@@ -1,0 +1,21 @@
+spec Bad {
+  scope broken {
+    use http
+    contract {
+      input {
+        count: int
+      }
+      output {
+        result: int
+      }
+    }
+    scenario smoke {
+      given {
+        count: "not_an_int"
+      }
+      then {
+        result: 0
+      }
+    }
+  }
+}

--- a/testdata/self/invalid_unknown_token.spec
+++ b/testdata/self/invalid_unknown_token.spec
@@ -1,0 +1,3 @@
+spec Bad {
+  foobar
+}

--- a/testdata/self/invalid_unknown_type.spec
+++ b/testdata/self/invalid_unknown_type.spec
@@ -1,0 +1,13 @@
+spec Bad {
+  scope broken {
+    use http
+    contract {
+      input {
+        item: Widget
+      }
+      output {
+        result: int
+      }
+    }
+  }
+}

--- a/testdata/self/invalid_unterminated_string.spec
+++ b/testdata/self/invalid_unterminated_string.spec
@@ -1,0 +1,8 @@
+spec Bad {
+  scope broken {
+    use http
+    config {
+      path: "/unterminated
+    }
+  }
+}

--- a/testdata/self/invalid_use_at_spec_level.spec
+++ b/testdata/self/invalid_use_at_spec_level.spec
@@ -1,0 +1,3 @@
+use http
+spec Bad {
+}


### PR DESCRIPTION
## Summary

- Add 15 new self-verification scenarios covering all known parser and validator rejection cases
- Split rejection tests into `parse_invalid` (syntax/parser errors) and `validate_invalid` (semantic/validator errors) scopes
- Create 13 new minimal fixture files in `testdata/self/` plus reuse 2 existing include fixtures

### Parser rejection scenarios (11 new)
- Missing `use` directive on scope
- Multiple `use` directives in same scope
- `use` at spec level (outside scope)
- Unknown token in spec body
- Malformed contract (unexpected keyword)
- Malformed `then` block syntax
- Unterminated string literal
- Single `&` (incomplete operator)
- Duplicate model names across includes
- Duplicate scope names across includes

### Validator rejection scenarios (5 new)
- Unknown type in model field
- Type mismatch in `given` block (string literal for int field)
- `null` for non-optional field
- Missing required field in `given` block
- `then` target not in contract output

## Test plan
- [x] `go test ./...` passes
- [x] `SPECRUN_BIN=./specrun ./specrun verify specs/speclang.spec` passes (26/26 scenarios, 4/4 invariants)
- [x] Each fixture file individually produces exit code 1

Closes #44