### PR TITLE
feat(specs): add verify_fail scope for broken implementation detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,10 @@ jobs:
           go run ./examples/server &
           sleep 1
 
+      - name: Start broken server
+        run: |
+          go run ./testdata/self/broken_server &
+          sleep 1
+
       - name: Self-verification
-        run: SPECRUN_BIN=./specrun APP_URL=http://localhost:8080 ./specrun verify specs/speclang.spec
+        run: SPECRUN_BIN=./specrun APP_URL=http://localhost:8080 BROKEN_APP_URL=http://localhost:8081 ./specrun verify specs/speclang.spec

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,7 +295,8 @@ speclang/
 │   ├── speclang.spec     # root: use process, includes parse/generate/verify
 │   ├── parse.spec        # parse_valid + parse_invalid scopes
 │   ├── generate.spec     # generator constraint satisfaction
-│   └── verify.spec       # verify_pass scope
+│   ├── verify.spec       # verify_pass scope
+│   └── verify_fail.spec  # verify_fail scope (broken implementation detection)
 └── testdata/
     ├── include/          # multi-file include test fixtures
     │   ├── basic/        # root includes models + scopes
@@ -400,6 +401,7 @@ The self-verification spec uses the process adapter to invoke `specrun` subcomma
 - **parse_invalid** — verifies the parser rejects malformed specs with exit code 1
 - **generate** — verifies the generator produces constraint-satisfying outputs across seeds
 - **verify_pass** — verifies that `specrun verify` passes correct implementations
+- **verify_fail** — verifies that `specrun verify` detects incorrect implementations
 
 Run self-verification:
 ```bash

--- a/cmd/specrun/main_test.go
+++ b/cmd/specrun/main_test.go
@@ -247,10 +247,14 @@ func TestSelfVerification_Parse(t *testing.T) {
 	srv := startTransferServer(t)
 	defer srv.Close()
 
+	brokenSrv := startBrokenTransferServer(t)
+	defer brokenSrv.Close()
+
 	cmd := exec.Command(bin, "verify", "--json", "--iterations", "10", specFile)
 	cmd.Env = append(os.Environ(),
 		"SPECRUN_BIN="+bin,
 		"APP_URL="+srv.URL,
+		"BROKEN_APP_URL="+brokenSrv.URL,
 	)
 	// Set working dir to project root so relative paths in specs resolve correctly.
 	cmd.Dir = projectRoot
@@ -308,6 +312,51 @@ func TestVerify_HumanOutput(t *testing.T) {
 	if !strings.Contains(output, "Scenarios:  3/3 passed") {
 		t.Errorf("missing scenario summary:\n%s", output)
 	}
+}
+
+// startBrokenTransferServer returns a test server that credits the to-account
+// but never debits the from-account (conservation invariant violation).
+func startBrokenTransferServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/accounts/transfer", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			From struct {
+				ID      string `json:"id"`
+				Balance int    `json:"balance"`
+			} `json:"from"`
+			To struct {
+				ID      string `json:"id"`
+				Balance int    `json:"balance"`
+			} `json:"to"`
+			Amount int `json:"amount"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp := map[string]any{
+			"from":  map[string]any{"id": req.From.ID, "balance": req.From.Balance},
+			"to":    map[string]any{"id": req.To.ID, "balance": req.To.Balance},
+			"error": nil,
+		}
+		switch {
+		case req.Amount <= 0:
+			resp["error"] = "invalid_amount"
+		case req.Amount > req.From.Balance:
+			resp["error"] = "insufficient_funds"
+		default:
+			// BUG: only credits to-account, does NOT debit from-account
+			resp["to"] = map[string]any{
+				"id": req.To.ID, "balance": req.To.Balance + req.Amount,
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+	return httptest.NewServer(mux)
 }
 
 func startTransferServer(t *testing.T) *httptest.Server {

--- a/specs/speclang.spec
+++ b/specs/speclang.spec
@@ -9,6 +9,7 @@ spec Speclang {
   include "parse.spec"
   include "generate.spec"
   include "verify.spec"
+  include "verify_fail.spec"
   include "types.spec"
   include "generate_types.spec"
 }

--- a/specs/verify_fail.spec
+++ b/specs/verify_fail.spec
@@ -1,0 +1,35 @@
+# Verifies that specrun verify detects incorrect implementations.
+scope verify_fail {
+  use process
+  config {
+    args: "verify --json"
+  }
+
+  contract {
+    input {
+      file: string
+    }
+    output {
+      exit_code: int
+      scenarios_run: int
+      scenarios_passed: int
+      invariants_checked: int
+      invariants_passed: int
+    }
+  }
+
+  # The broken server credits the to-account but never debits the from-account,
+  # so the conservation invariant must fail.
+  scenario broken_server_detected {
+    given {
+      file: "testdata/self/broken_transfer.spec"
+    }
+    then {
+      exit_code: 1
+      scenarios_run: 1
+      scenarios_passed: 0
+      invariants_checked: 1
+      invariants_passed: 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `verify_fail` scope to self-verification specs that asserts specrun correctly detects incorrect implementations
- Uses existing `broken_transfer.spec` fixture and `broken_server` (credits to-account but never debits from-account)
- Asserts `exit_code: 1`, `scenarios_passed: 0`, `invariants_passed: 0`
- Updates CI to start the broken server alongside the example server
- Adds `startBrokenTransferServer` test helper for Go unit tests

## Test plan

- [x] `go test ./...` passes locally
- [x] Self-verification test (`TestSelfVerification_Parse`) exercises the new scope
- [ ] CI passes with both servers running

Closes #43