### PR TITLE
feat(expr): add division and modulo operators

### DIFF
--- a/pkg/generator/divmod_test.go
+++ b/pkg/generator/divmod_test.go
@@ -1,0 +1,197 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/bamsammich/speclang/v2/pkg/parser"
+)
+
+func TestIntDivision(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		l, r int
+		want int
+	}{
+		{"10/3", 10, 3, 3},
+		{"9/3", 9, 3, 3},
+		{"7/2", 7, 2, 3},
+		{"0/5", 0, 5, 0},
+		{"100/10", 100, 10, 10},
+		{"-7/2", -7, 2, -3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, ok := evalBinaryValues("/", tt.l, tt.r)
+			if !ok {
+				t.Fatal("int division failed")
+			}
+			if result != tt.want {
+				t.Errorf("%d / %d = %v, want %d", tt.l, tt.r, result, tt.want)
+			}
+		})
+	}
+}
+
+func TestFloatDivision(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		l, r float64
+		want float64
+	}{
+		{"10.0/3.0", 10.0, 3.0, 10.0 / 3.0},
+		{"7.5/2.5", 7.5, 2.5, 3.0},
+		{"1.0/4.0", 1.0, 4.0, 0.25},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, ok := evalBinaryValues("/", tt.l, tt.r)
+			if !ok {
+				t.Fatal("float division failed")
+			}
+			if result != tt.want {
+				t.Errorf("%v / %v = %v, want %v", tt.l, tt.r, result, tt.want)
+			}
+		})
+	}
+}
+
+func TestMixedIntFloatDivision(t *testing.T) {
+	t.Parallel()
+
+	// int / float64 should use float path
+	result, ok := evalBinaryValues("/", int(7), float64(2.0))
+	if !ok {
+		t.Fatal("mixed int/float division failed")
+	}
+	if result != float64(3.5) {
+		t.Errorf("7 / 2.0 = %v, want 3.5", result)
+	}
+
+	// float64 / int should use float path
+	result, ok = evalBinaryValues("/", float64(7.0), int(2))
+	if !ok {
+		t.Fatal("mixed float/int division failed")
+	}
+	if result != float64(3.5) {
+		t.Errorf("7.0 / 2 = %v, want 3.5", result)
+	}
+}
+
+func TestIntModulo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		l, r int
+		want int
+	}{
+		{"10%3", 10, 3, 1},
+		{"9%3", 9, 3, 0},
+		{"7%2", 7, 2, 1},
+		{"0%5", 0, 5, 0},
+		{"100%7", 100, 7, 2},
+		{"-7%2", -7, 2, -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, ok := evalBinaryValues("%", tt.l, tt.r)
+			if !ok {
+				t.Fatal("int modulo failed")
+			}
+			if result != tt.want {
+				t.Errorf("%d %% %d = %v, want %d", tt.l, tt.r, result, tt.want)
+			}
+		})
+	}
+}
+
+func TestDivisionByZero_Int(t *testing.T) {
+	t.Parallel()
+
+	_, ok := evalBinaryValues("/", int(10), int(0))
+	if ok {
+		t.Error("int division by zero should fail")
+	}
+}
+
+func TestDivisionByZero_Float(t *testing.T) {
+	t.Parallel()
+
+	_, ok := evalBinaryValues("/", float64(10.0), float64(0.0))
+	if ok {
+		t.Error("float division by zero should fail")
+	}
+}
+
+func TestModuloByZero(t *testing.T) {
+	t.Parallel()
+
+	_, ok := evalBinaryValues("%", int(10), int(0))
+	if ok {
+		t.Error("modulo by zero should fail")
+	}
+}
+
+func TestModuloFloat_Unsupported(t *testing.T) {
+	t.Parallel()
+
+	// Modulo is only defined for integers
+	_, ok := evalBinaryValues("%", float64(10.0), float64(3.0))
+	if ok {
+		t.Error("float modulo should fail")
+	}
+
+	// Mixed int/float modulo should also fail
+	_, ok = evalBinaryValues("%", int(10), float64(3.0))
+	if ok {
+		t.Error("mixed int/float modulo should fail")
+	}
+}
+
+func TestEvalDivModExpressions(t *testing.T) {
+	t.Parallel()
+
+	// Test via the full Eval path (expression tree evaluation)
+	vars := map[string]any{"a": 10, "b": 3}
+
+	// a / b == 3
+	result, ok := Eval(parser.BinaryOp{
+		Left: parser.BinaryOp{
+			Left:  parser.FieldRef{Path: "a"},
+			Op:    "/",
+			Right: parser.FieldRef{Path: "b"},
+		},
+		Op:    "==",
+		Right: parser.LiteralInt{Value: 3},
+	}, vars)
+	if !ok {
+		t.Fatal("eval a/b==3 failed")
+	}
+	if result != true {
+		t.Errorf("10/3 == 3 should be true, got %v", result)
+	}
+
+	// a % b == 1
+	result, ok = Eval(parser.BinaryOp{
+		Left: parser.BinaryOp{
+			Left:  parser.FieldRef{Path: "a"},
+			Op:    "%",
+			Right: parser.FieldRef{Path: "b"},
+		},
+		Op:    "==",
+		Right: parser.LiteralInt{Value: 1},
+	}, vars)
+	if !ok {
+		t.Fatal("eval a mod b == 1 failed")
+	}
+	if result != true {
+		t.Errorf("10%%3 == 1 should be true, got %v", result)
+	}
+}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -408,12 +408,16 @@ func evalBinaryValues(op string, left, right any) (any, bool) {
 		return evalBoolOp(op, left, right)
 	case "==", "!=":
 		return evalEqualityOp(op, left, right)
-	case "<", "<=", ">", ">=", "+", "-", "*":
+	case "<", "<=", ">", ">=", "+", "-", "*", "/", "%":
 		// If both sides are native int, use int arithmetic (avoids float precision issues).
 		ln, lok := left.(int)
 		rn, rok := right.(int)
 		if lok && rok {
 			return evalIntOp(op, ln, rn)
+		}
+		// Modulo is only defined for integers.
+		if op == "%" {
+			return nil, false
 		}
 		// Otherwise try float arithmetic (handles float64 from JSON and float type).
 		lf, lfok := toFloat(left)
@@ -471,6 +475,16 @@ func evalIntOp(op string, l, r int) (any, bool) {
 		return l - r, true
 	case "*":
 		return l * r, true
+	case "/":
+		if r == 0 {
+			return nil, false
+		}
+		return l / r, true
+	case "%":
+		if r == 0 {
+			return nil, false
+		}
+		return l % r, true
 	default:
 		return nil, false
 	}
@@ -492,6 +506,11 @@ func evalFloatOp(op string, l, r float64) (any, bool) {
 		return l - r, true
 	case "*":
 		return l * r, true
+	case "/":
+		if r == 0 {
+			return nil, false
+		}
+		return l / r, true
 	default:
 		return nil, false
 	}

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -159,7 +159,7 @@ type EnvRef struct {
 type BinaryOp struct {
 	Left  Expr   `json:"left,omitempty"`
 	Right Expr   `json:"right,omitempty"`
-	Op    string `json:"op"` // ==, !=, >, <, >=, <=, +, -, *, &&, ||
+	Op    string `json:"op"` // ==, !=, >, <, >=, <=, +, -, *, /, %, &&, ||
 }
 
 type UnaryOp struct {

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -77,8 +77,10 @@ const (
 	TokenLte    // <=
 	TokenPlus   // +
 	TokenMinus  // -
-	TokenStar   // *
-	TokenAnd    // &&
+	TokenStar    // *
+	TokenSlash   // /
+	TokenPercent // %
+	TokenAnd     // &&
 	TokenOr     // ||
 	TokenNot    // !
 	TokenAssign // =
@@ -135,6 +137,8 @@ var tokenNames = map[TokenType]string{
 	TokenPlus:      "Plus",
 	TokenMinus:     "Minus",
 	TokenStar:      "Star",
+	TokenSlash:     "Slash",
+	TokenPercent:   "Percent",
 	TokenAnd:       "And",
 	TokenOr:        "Or",
 	TokenNot:       "Not",
@@ -192,6 +196,8 @@ var singleCharTokens = map[rune]TokenType{
 	'+': TokenPlus,
 	'-': TokenMinus,
 	'*': TokenStar,
+	'/': TokenSlash,
+	'%': TokenPercent,
 }
 
 type lexer struct {

--- a/pkg/parser/lexer_test.go
+++ b/pkg/parser/lexer_test.go
@@ -69,13 +69,13 @@ func TestLexTransferSpec(t *testing.T) {
 }
 
 func TestLexOperators(t *testing.T) {
-	tokens, err := Lex("== != > < >= <= + - * && ||")
+	tokens, err := Lex("== != > < >= <= + - * / % && ||")
 	if err != nil {
 		t.Fatal(err)
 	}
 	expected := []TokenType{
 		TokenEq, TokenNeq, TokenGt, TokenLt, TokenGte, TokenLte,
-		TokenPlus, TokenMinus, TokenStar, TokenAnd, TokenOr, TokenEOF,
+		TokenPlus, TokenMinus, TokenStar, TokenSlash, TokenPercent, TokenAnd, TokenOr, TokenEOF,
 	}
 	if len(tokens) != len(expected) {
 		t.Fatalf("expected %d tokens, got %d", len(expected), len(tokens))

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -978,7 +978,7 @@ func infixPrec(typ TokenType) int {
 		return precComparison
 	case TokenPlus, TokenMinus:
 		return precAdditive
-	case TokenStar:
+	case TokenStar, TokenSlash, TokenPercent:
 		return precMultiply
 	default:
 		return precNone
@@ -994,8 +994,10 @@ var opStrings = map[TokenType]string{
 	TokenLte:   "<=",
 	TokenPlus:  "+",
 	TokenMinus: "-",
-	TokenStar:  "*",
-	TokenAnd:   "&&",
+	TokenStar:    "*",
+	TokenSlash:   "/",
+	TokenPercent: "%",
+	TokenAnd:     "&&",
 	TokenOr:    "||",
 }
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -471,6 +471,36 @@ func TestParseExprPrecedence(t *testing.T) {
 			},
 		},
 		{
+			name:  "division at multiplicative precedence",
+			input: "spec T { scope s { use http invariant i { a + b / c } } }",
+			checkFn: func(t *testing.T, expr parser.Expr) {
+				t.Helper()
+				plus, ok := expr.(parser.BinaryOp)
+				if !ok || plus.Op != "+" {
+					t.Fatalf("expected +, got %v", expr)
+				}
+				div, ok := plus.Right.(parser.BinaryOp)
+				if !ok || div.Op != "/" {
+					t.Errorf("expected / on right of +, got %v", plus.Right)
+				}
+			},
+		},
+		{
+			name:  "modulo at multiplicative precedence",
+			input: "spec T { scope s { use http invariant i { a + b % c } } }",
+			checkFn: func(t *testing.T, expr parser.Expr) {
+				t.Helper()
+				plus, ok := expr.(parser.BinaryOp)
+				if !ok || plus.Op != "+" {
+					t.Fatalf("expected +, got %v", expr)
+				}
+				mod, ok := plus.Right.(parser.BinaryOp)
+				if !ok || mod.Op != "%" {
+					t.Errorf("expected %% on right of +, got %v", plus.Right)
+				}
+			},
+		},
+		{
 			name:  "unary negation",
 			input: "spec T { scope s { use http invariant i { !a } } }",
 			checkFn: func(t *testing.T, expr parser.Expr) {

--- a/skills/author/references/api_reference.md
+++ b/skills/author/references/api_reference.md
@@ -81,7 +81,7 @@ spec <Name> {
 - **Environment**: `env(VAR)`, `env(VAR, "default")`
 - **Objects**: `{ id: "alice", balance: 100 }`
 - **Arrays**: `[expr, expr, ...]` — comma-separated list of expressions of the same type
-- **Operators**: `==`, `!=`, `>`, `<`, `>=`, `<=`, `+`, `-`, `*`, `&&`, `||`, `!`
+- **Operators**: `==`, `!=`, `>`, `<`, `>=`, `<=`, `+`, `-`, `*`, `/`, `%`, `&&`, `||`, `!`
 - **Functions**: `len(expr)` — returns length of array, map, or string
 
 ## Comments


### PR DESCRIPTION
## Summary

- Add `/` (division) and `%` (modulo) operators to the expression parser at multiplicative precedence (same as `*`)
- Implement evaluation: integer division for int/int, float division for float/float or mixed, modulo for integers only
- Division by zero returns evaluation failure for both int and float types

## Test plan

- [x] Unit tests for int division, float division, mixed int/float division
- [x] Unit tests for int modulo, including negative operands
- [x] Unit tests for division by zero (int and float) and modulo by zero
- [x] Unit tests for float modulo rejection
- [x] Parser precedence tests for `/` and `%` at multiplicative level
- [x] Lexer test updated to include `/` and `%` tokens
- [x] Full Eval path test through expression tree
- [x] `go test ./... -count=1` passes
- [x] Self-verification passes (`specrun verify specs/speclang.spec`)

Closes #40