### PR TITLE
feat(types): add enum type for discrete value domains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,9 @@ spec <Name> {
   }
 
   model <Name> {
-    <field>: <type>
+    <field>: <type>                    # int, float, string, bytes, bool, any,
+                                       # []T, map[K,V], enum("a","b",...), ModelName
+                                       # append ? for optional: string?, enum(...)?
     <field>: <type> { <constraint> }
   }
 

--- a/pkg/generator/enum_test.go
+++ b/pkg/generator/enum_test.go
@@ -1,0 +1,146 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/bamsammich/speclang/v2/pkg/parser"
+)
+
+func TestGenerateEnum(t *testing.T) {
+	variants := []string{"http", "process", "playwright"}
+	g := New(
+		&parser.Contract{
+			Input: []*parser.Field{
+				{Name: "plugin", Type: parser.TypeExpr{Name: "enum", Variants: variants}},
+			},
+		},
+		nil, 42,
+	)
+
+	seen := make(map[string]bool)
+	for range 100 {
+		input, err := g.GenerateInput()
+		if err != nil {
+			t.Fatal(err)
+		}
+		val, ok := input["plugin"].(string)
+		if !ok {
+			t.Fatalf("expected string for plugin, got %T", input["plugin"])
+		}
+		seen[val] = true
+		// Verify it's a valid variant
+		found := false
+		for _, v := range variants {
+			if val == v {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("generated %q which is not a valid variant", val)
+		}
+	}
+
+	// With 100 draws from 3 variants, we should see all of them
+	for _, v := range variants {
+		if !seen[v] {
+			t.Errorf("variant %q was never generated in 100 draws", v)
+		}
+	}
+}
+
+func TestGenerateEnum_SingleVariant(t *testing.T) {
+	g := New(
+		&parser.Contract{
+			Input: []*parser.Field{
+				{Name: "mode", Type: parser.TypeExpr{Name: "enum", Variants: []string{"default"}}},
+			},
+		},
+		nil, 42,
+	)
+
+	input, err := g.GenerateInput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	val, ok := input["mode"].(string)
+	if !ok {
+		t.Fatalf("expected string, got %T", input["mode"])
+	}
+	if val != "default" {
+		t.Errorf("got %q, want 'default'", val)
+	}
+}
+
+func TestGenerateEnum_Optional(t *testing.T) {
+	g := New(
+		&parser.Contract{
+			Input: []*parser.Field{
+				{Name: "role", Type: parser.TypeExpr{Name: "enum", Variants: []string{"admin", "user"}, Optional: true}},
+			},
+		},
+		nil, 42,
+	)
+
+	sawNil := false
+	sawValue := false
+	for range 100 {
+		input, err := g.GenerateInput()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if input["role"] == nil {
+			sawNil = true
+		} else {
+			sawValue = true
+			val, ok := input["role"].(string)
+			if !ok {
+				t.Fatalf("expected string or nil, got %T", input["role"])
+			}
+			if val != "admin" && val != "user" {
+				t.Errorf("got %q, want 'admin' or 'user'", val)
+			}
+		}
+	}
+	if !sawNil {
+		t.Error("optional enum never produced nil in 100 draws")
+	}
+	if !sawValue {
+		t.Error("optional enum never produced a value in 100 draws")
+	}
+}
+
+func TestShrinkEnum(t *testing.T) {
+	variants := []string{"alpha", "beta", "gamma"}
+	input := map[string]any{"plugin": "gamma"}
+	fields := []*parser.Field{
+		{Name: "plugin", Type: parser.TypeExpr{Name: "enum", Variants: variants}},
+	}
+
+	// stillFails returns true for any variant (so shrinking picks the first)
+	result := Shrink(input, fields, nil, func(m map[string]any) bool {
+		return true
+	})
+
+	if result["plugin"] != "alpha" {
+		t.Errorf("shrunk to %q, want 'alpha' (first variant)", result["plugin"])
+	}
+}
+
+func TestShrinkEnum_SpecificVariant(t *testing.T) {
+	variants := []string{"alpha", "beta", "gamma"}
+	input := map[string]any{"plugin": "gamma"}
+	fields := []*parser.Field{
+		{Name: "plugin", Type: parser.TypeExpr{Name: "enum", Variants: variants}},
+	}
+
+	// Only fails for "beta" and "gamma"
+	result := Shrink(input, fields, nil, func(m map[string]any) bool {
+		v := m["plugin"].(string)
+		return v == "beta" || v == "gamma"
+	})
+
+	if result["plugin"] != "beta" {
+		t.Errorf("shrunk to %q, want 'beta' (earliest failing variant)", result["plugin"])
+	}
+}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -136,6 +136,11 @@ func (g *Generator) generateValue(rng *rand.Rand, t parser.TypeExpr) any {
 			return g.generateMap(rng, *t.ValType)
 		}
 		return nil
+	case "enum":
+		if len(t.Variants) > 0 {
+			return t.Variants[rng.IntN(len(t.Variants))]
+		}
+		return nil
 	default:
 		return nil
 	}

--- a/pkg/generator/shrink.go
+++ b/pkg/generator/shrink.go
@@ -44,6 +44,8 @@ func shrinkField(
 		return shrinkArray(input, field.Name, stillFails)
 	case "map":
 		return shrinkMap(input, field.Name, stillFails)
+	case "enum":
+		return shrinkEnum(input, field.Name, field.Type.Variants, stillFails)
 	}
 
 	// Model lookup for named model types.
@@ -60,6 +62,26 @@ func shrinkField(
 	default:
 		return input
 	}
+}
+
+// shrinkEnum tries each variant in order, keeping the first (earliest-index)
+// variant that still causes the failure.
+func shrinkEnum(
+	input map[string]any,
+	name string,
+	variants []string,
+	stillFails func(map[string]any) bool,
+) map[string]any {
+	current := copyMap(input)
+	for _, v := range variants {
+		candidate := copyMap(current)
+		candidate[name] = v
+		if stillFails(candidate) {
+			current[name] = v
+			return current
+		}
+	}
+	return current
 }
 
 // shrinkInt binary searches toward 0.

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -43,10 +43,11 @@ type Field struct {
 
 // TypeExpr represents a type in the spec language.
 type TypeExpr struct {
-	Name     string    `json:"name"`                    // "int", "string", "bool", "float", "bytes", "array", "map", or model name
+	Name     string    `json:"name"`                    // "int", "string", "bool", "float", "bytes", "array", "map", "enum", or model name
 	ElemType *TypeExpr `json:"elem_type,omitempty"`     // element type for arrays
 	KeyType  *TypeExpr `json:"key_type,omitempty"`      // key type for maps
 	ValType  *TypeExpr `json:"val_type,omitempty"`      // value type for maps
+	Variants []string  `json:"variants,omitempty"`      // enum variants (for enum type)
 	Optional bool      `json:"optional,omitempty"`      // trailing ?
 }
 

--- a/pkg/parser/enum_test.go
+++ b/pkg/parser/enum_test.go
@@ -1,0 +1,213 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestParseEnumType(t *testing.T) {
+	spec, err := Parse(`
+spec Test {
+  scope test {
+    use http
+    contract {
+      input {
+        status: enum("active", "inactive", "pending")
+      }
+      output {
+        ok: bool
+      }
+    }
+  }
+}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	field := spec.Scopes[0].Contract.Input[0]
+	if field.Type.Name != "enum" {
+		t.Errorf("type name = %q, want 'enum'", field.Type.Name)
+	}
+	if len(field.Type.Variants) != 3 {
+		t.Fatalf("variants count = %d, want 3", len(field.Type.Variants))
+	}
+	want := []string{"active", "inactive", "pending"}
+	for i, v := range want {
+		if field.Type.Variants[i] != v {
+			t.Errorf("variant[%d] = %q, want %q", i, field.Type.Variants[i], v)
+		}
+	}
+}
+
+func TestParseEnumType_SingleVariant(t *testing.T) {
+	spec, err := Parse(`
+spec Test {
+  scope test {
+    use http
+    contract {
+      input {
+        mode: enum("default")
+      }
+      output {
+        ok: bool
+      }
+    }
+  }
+}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	field := spec.Scopes[0].Contract.Input[0]
+	if field.Type.Name != "enum" {
+		t.Errorf("type name = %q, want 'enum'", field.Type.Name)
+	}
+	if len(field.Type.Variants) != 1 {
+		t.Fatalf("variants count = %d, want 1", len(field.Type.Variants))
+	}
+	if field.Type.Variants[0] != "default" {
+		t.Errorf("variant[0] = %q, want 'default'", field.Type.Variants[0])
+	}
+}
+
+func TestParseEnumType_Optional(t *testing.T) {
+	spec, err := Parse(`
+spec Test {
+  scope test {
+    use http
+    contract {
+      input {
+        role: enum("admin", "user")?
+      }
+      output {
+        ok: bool
+      }
+    }
+  }
+}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	field := spec.Scopes[0].Contract.Input[0]
+	if field.Type.Name != "enum" {
+		t.Errorf("type name = %q, want 'enum'", field.Type.Name)
+	}
+	if !field.Type.Optional {
+		t.Error("expected optional enum")
+	}
+	if len(field.Type.Variants) != 2 {
+		t.Fatalf("variants count = %d, want 2", len(field.Type.Variants))
+	}
+}
+
+func TestParseEnumType_TrailingComma(t *testing.T) {
+	spec, err := Parse(`
+spec Test {
+  scope test {
+    use http
+    contract {
+      input {
+        color: enum("red", "green", "blue",)
+      }
+      output {
+        ok: bool
+      }
+    }
+  }
+}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	field := spec.Scopes[0].Contract.Input[0]
+	if len(field.Type.Variants) != 3 {
+		t.Fatalf("variants count = %d, want 3 (trailing comma)", len(field.Type.Variants))
+	}
+}
+
+func TestParseEnumType_Empty(t *testing.T) {
+	_, err := Parse(`
+spec Test {
+  scope test {
+    use http
+    contract {
+      input {
+        status: enum()
+      }
+      output {
+        ok: bool
+      }
+    }
+  }
+}
+`)
+	if err == nil {
+		t.Fatal("expected parse error for empty enum")
+	}
+}
+
+func TestParseEnumType_NonStringVariant(t *testing.T) {
+	_, err := Parse(`
+spec Test {
+  scope test {
+    use http
+    contract {
+      input {
+        status: enum(1, 2, 3)
+      }
+      output {
+        ok: bool
+      }
+    }
+  }
+}
+`)
+	if err == nil {
+		t.Fatal("expected parse error for non-string enum variant")
+	}
+}
+
+func TestParseEnumType_InGiven(t *testing.T) {
+	spec, err := Parse(`
+spec Test {
+  scope test {
+    use http
+    contract {
+      input {
+        status: enum("active", "inactive")
+      }
+      output {
+        ok: bool
+      }
+    }
+    scenario smoke {
+      given {
+        status: "active"
+      }
+      then {
+        ok: true
+      }
+    }
+  }
+}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc := spec.Scopes[0].Scenarios[0]
+	a, ok := sc.Given.Steps[0].(*Assignment)
+	if !ok {
+		t.Fatalf("expected *Assignment, got %T", sc.Given.Steps[0])
+	}
+	lit, ok := a.Value.(LiteralString)
+	if !ok {
+		t.Fatalf("expected LiteralString, got %T", a.Value)
+	}
+	if lit.Value != "active" {
+		t.Errorf("value = %q, want 'active'", lit.Value)
+	}
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -530,6 +530,35 @@ func (p *parser) parseTypeExprInner() (TypeExpr, error) {
 		return TypeExpr{Name: "map", KeyType: &keyType, ValType: &valType}, nil
 	}
 
+	// Enum type: enum("val1", "val2", ...)
+	if name.Value == "enum" && p.peek().Type == TokenLParen {
+		p.advance() // consume (
+		var variants []string
+		for p.peek().Type != TokenRParen {
+			if len(variants) > 0 {
+				if _, err := p.expect(TokenComma); err != nil {
+					return TypeExpr{}, err
+				}
+				// Allow trailing comma
+				if p.peek().Type == TokenRParen {
+					break
+				}
+			}
+			tok, err := p.expect(TokenString)
+			if err != nil {
+				return TypeExpr{}, p.errAt(p.peek(), "enum variants must be string literals")
+			}
+			variants = append(variants, tok.Value)
+		}
+		if _, err := p.expect(TokenRParen); err != nil {
+			return TypeExpr{}, err
+		}
+		if len(variants) == 0 {
+			return TypeExpr{}, p.errAt(name, "enum type requires at least one variant")
+		}
+		return TypeExpr{Name: "enum", Variants: variants}, nil
+	}
+
 	return TypeExpr{Name: name.Value}, nil
 }
 

--- a/pkg/validator/enum_test.go
+++ b/pkg/validator/enum_test.go
@@ -1,0 +1,155 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/bamsammich/speclang/v2/pkg/parser"
+)
+
+func TestValidate_EnumValidVariant(t *testing.T) {
+	spec := &parser.Spec{
+		Scopes: []*parser.Scope{
+			{
+				Name: "test",
+				Use:  "http",
+				Contract: &parser.Contract{
+					Input: []*parser.Field{
+						{Name: "status", Type: parser.TypeExpr{Name: "enum", Variants: []string{"active", "inactive"}}},
+					},
+				},
+				Scenarios: []*parser.Scenario{
+					{
+						Name: "smoke",
+						Given: &parser.Block{
+							Steps: []parser.GivenStep{
+								&parser.Assignment{Path: "status", Value: parser.LiteralString{Value: "active"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errs := Validate(spec)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got: %v", errs)
+	}
+}
+
+func TestValidate_EnumInvalidVariant(t *testing.T) {
+	spec := &parser.Spec{
+		Scopes: []*parser.Scope{
+			{
+				Name: "test",
+				Use:  "http",
+				Contract: &parser.Contract{
+					Input: []*parser.Field{
+						{Name: "status", Type: parser.TypeExpr{Name: "enum", Variants: []string{"active", "inactive"}}},
+					},
+				},
+				Scenarios: []*parser.Scenario{
+					{
+						Name: "smoke",
+						Given: &parser.Block{
+							Steps: []parser.GivenStep{
+								&parser.Assignment{Path: "status", Value: parser.LiteralString{Value: "deleted"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errs := Validate(spec)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error for invalid variant, got %d: %v", len(errs), errs)
+	}
+	if !contains(errs[0].Error(), "deleted") {
+		t.Errorf("expected error about 'deleted', got: %v", errs[0])
+	}
+}
+
+func TestValidate_EnumWrongLiteralType(t *testing.T) {
+	spec := &parser.Spec{
+		Scopes: []*parser.Scope{
+			{
+				Name: "test",
+				Use:  "http",
+				Contract: &parser.Contract{
+					Input: []*parser.Field{
+						{Name: "status", Type: parser.TypeExpr{Name: "enum", Variants: []string{"active", "inactive"}}},
+					},
+				},
+				Scenarios: []*parser.Scenario{
+					{
+						Name: "smoke",
+						Given: &parser.Block{
+							Steps: []parser.GivenStep{
+								&parser.Assignment{Path: "status", Value: parser.LiteralInt{Value: 42}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errs := Validate(spec)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error for non-string assigned to enum, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidate_EnumInContractPasses(t *testing.T) {
+	spec := &parser.Spec{
+		Scopes: []*parser.Scope{
+			{
+				Name: "test",
+				Use:  "http",
+				Contract: &parser.Contract{
+					Input: []*parser.Field{
+						{Name: "status", Type: parser.TypeExpr{Name: "enum", Variants: []string{"a", "b"}}},
+					},
+				},
+			},
+		},
+	}
+
+	errs := Validate(spec)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got: %v", errs)
+	}
+}
+
+func TestValidate_EnumNullForOptional(t *testing.T) {
+	spec := &parser.Spec{
+		Scopes: []*parser.Scope{
+			{
+				Name: "test",
+				Use:  "http",
+				Contract: &parser.Contract{
+					Input: []*parser.Field{
+						{Name: "role", Type: parser.TypeExpr{Name: "enum", Variants: []string{"admin", "user"}, Optional: true}},
+					},
+				},
+				Scenarios: []*parser.Scenario{
+					{
+						Name: "smoke",
+						Given: &parser.Block{
+							Steps: []parser.GivenStep{
+								&parser.Assignment{Path: "role", Value: parser.LiteralNull{}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errs := Validate(spec)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors for null on optional enum, got: %v", errs)
+	}
+}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -11,7 +11,7 @@ import (
 var primitives = map[string]bool{
 	"int": true, "string": true, "bool": true,
 	"float": true, "bytes": true, "array": true, "map": true,
-	"any": true,
+	"enum": true, "any": true,
 }
 
 // Validate performs post-parse semantic validation on a spec.
@@ -200,6 +200,24 @@ func (v *validator) checkExprType(expr parser.Expr, te parser.TypeExpr, context 
 				v.errorf("%s: expected bool, got %s", context, exprTypeName(expr))
 			}
 		}
+	case "enum":
+		str, ok := expr.(parser.LiteralString)
+		if !ok {
+			if !isNonLiteral(expr) {
+				v.errorf("%s: expected enum value, got %s", context, exprTypeName(expr))
+			}
+			return
+		}
+		found := false
+		for _, variant := range te.Variants {
+			if str.Value == variant {
+				found = true
+				break
+			}
+		}
+		if !found {
+			v.errorf("%s: %q is not a valid enum variant (expected one of %v)", context, str.Value, te.Variants)
+		}
 	case "array":
 		arr, ok := expr.(parser.ArrayLiteral)
 		if !ok {
@@ -263,6 +281,8 @@ func typeName(te parser.TypeExpr) string {
 		return "[]unknown"
 	case "map":
 		return "map"
+	case "enum":
+		return fmt.Sprintf("enum(%v)", te.Variants)
 	default:
 		name := te.Name
 		if te.Optional {

--- a/skills/author/references/api_reference.md
+++ b/skills/author/references/api_reference.md
@@ -71,8 +71,9 @@ spec <Name> {
 - `any` — untyped (passed through)
 - `[]T` — array/slice of type T (e.g., `[]int`, `[]Account`)
 - `map[K, V]` — map with key type K and value type V (e.g., `map[string, int]`)
+- `enum("val1", "val2", ...)` — one of a fixed set of string values (e.g., `enum("http", "process", "playwright")`)
 - `<ModelName>` — reference to a defined model
-- Append `?` for optional: `string?`, `[]int?` (optional array)
+- Append `?` for optional: `string?`, `[]int?`, `enum("a", "b")?` (optional)
 
 ## Expressions
 

--- a/specs/enum.spec
+++ b/specs/enum.spec
@@ -1,0 +1,118 @@
+# Verifies the parser and generator handle enum types.
+scope parse_enum {
+  use process
+  config {
+    args: "parse"
+  }
+
+  contract {
+    input {
+      file: string
+    }
+    output {
+      exit_code: int
+      name: string
+    }
+  }
+
+  # Enum spec should parse successfully.
+  scenario enum_spec {
+    given {
+      file: "testdata/self/enum.spec"
+    }
+    then {
+      exit_code: 0
+      name: "EnumTest"
+    }
+  }
+}
+
+# Verifies the parser rejects empty enum types.
+scope parse_enum_invalid {
+  use process
+  config {
+    args: "parse"
+  }
+
+  contract {
+    input {
+      file: string
+    }
+    output {
+      exit_code: int
+    }
+  }
+
+  # Empty enum() should fail at parse time.
+  scenario empty_enum {
+    given {
+      file: "testdata/self/invalid_enum_empty.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+}
+
+# Verifies the validator rejects invalid enum variants.
+scope validate_enum_invalid {
+  use process
+  config {
+    args: "parse"
+  }
+
+  contract {
+    input {
+      file: string
+    }
+    output {
+      exit_code: int
+    }
+  }
+
+  # Assigning a string not in the variant set should fail validation.
+  scenario invalid_variant {
+    given {
+      file: "testdata/self/invalid_enum_variant.spec"
+    }
+    then {
+      exit_code: 1
+    }
+  }
+}
+
+# Verifies the generator produces valid enum values.
+scope generate_enum {
+  use process
+  config {
+    args: "generate testdata/self/enum.spec --scope enum_inputs --seed"
+  }
+
+  contract {
+    input {
+      seed: int
+    }
+    output {
+      exit_code: int
+      adapter_name: any
+      subcommand: any
+    }
+  }
+
+  # Generation should succeed across seeds.
+  invariant produces_output {
+    exit_code == 0
+  }
+
+  # Generated adapter_name values must be valid variants.
+  invariant adapter_name_is_valid {
+    when exit_code == 0:
+      output.adapter_name == "http" || output.adapter_name == "process" || output.adapter_name == "playwright"
+  }
+
+  # Generated subcommand values must be valid variants.
+  invariant subcommand_is_valid {
+    when exit_code == 0:
+      output.subcommand == "parse" || output.subcommand == "generate" || output.subcommand == "verify" || output.subcommand == "install"
+  }
+}

--- a/specs/speclang.spec
+++ b/specs/speclang.spec
@@ -14,4 +14,5 @@ spec Speclang {
   include "generate_types.spec"
   include "cli_flags.spec"
   include "adapters.spec"
+  include "enum.spec"
 }

--- a/testdata/self/enum.spec
+++ b/testdata/self/enum.spec
@@ -1,0 +1,37 @@
+spec EnumTest {
+  description: "Fixture exercising enum type for generator and parser testing"
+
+  target {
+    base_url: "http://localhost:8080"
+  }
+
+  scope enum_inputs {
+    use http
+    config {
+      path: "/test"
+      method: "POST"
+    }
+
+    contract {
+      input {
+        adapter_name: enum("http", "process", "playwright")
+        subcommand: enum("parse", "generate", "verify", "install")
+        opt_role: enum("admin", "user")?
+      }
+      output {
+        ok: bool
+      }
+    }
+
+    scenario smoke {
+      given {
+        adapter_name: "http"
+        subcommand: "parse"
+        opt_role: "admin"
+      }
+      then {
+        ok: true
+      }
+    }
+  }
+}

--- a/testdata/self/invalid_enum_empty.spec
+++ b/testdata/self/invalid_enum_empty.spec
@@ -1,0 +1,17 @@
+spec InvalidEnumEmpty {
+  scope test {
+    use http
+    config {
+      path: "/test"
+      method: "POST"
+    }
+    contract {
+      input {
+        status: enum()
+      }
+      output {
+        ok: bool
+      }
+    }
+  }
+}

--- a/testdata/self/invalid_enum_variant.spec
+++ b/testdata/self/invalid_enum_variant.spec
@@ -1,0 +1,25 @@
+spec InvalidEnumVariant {
+  scope test {
+    use http
+    config {
+      path: "/test"
+      method: "POST"
+    }
+    contract {
+      input {
+        status: enum("active", "inactive")
+      }
+      output {
+        ok: bool
+      }
+    }
+    scenario smoke {
+      given {
+        status: "deleted"
+      }
+      then {
+        ok: true
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `enum("val1", "val2", ...)` as a type expression: parser, generator (uniform pick), validator (rejects non-variants), and shrinker (tries all variants in order)
- Unit tests for parser (normal, single-variant, optional, trailing comma, empty error, non-string error), generator (distribution, single, optional), validator (valid/invalid variant, wrong type, null-optional), and shrinker (first-variant, earliest-failing)
- Self-verification specs: parse, parse-invalid (empty enum), validate-invalid (bad variant), and generator invariants asserting all generated values are valid variants
- Documentation updated: CLAUDE.md type comment, api_reference.md type listing

Closes #35

## Test plan

- [x] `go test ./... -count=1` passes
- [x] Full self-verification passes (41 scenarios, 17 invariants including 4 new enum scopes)
- [ ] CI passes