### PR TITLE
feat(expr): add conditional expressions (if/then/else)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,19 @@ The import is resolved at parse time. The parser dispatches to a pluggable `Impo
 - Each scope must declare `use <plugin>` to specify which adapter drives it. Different scopes in the same spec can use different plugins.
 - Contracts, invariants, and scenarios must live inside a scope (not at spec top-level).
 
+### Expressions
+
+Expressions appear in constraints, invariants, `when` predicates, and `then` assertions.
+
+- **Literals**: `42`, `3.14`, `"hello"`, `true`, `false`, `null`
+- **Field references**: `from.balance`, `output.error`
+- **Environment**: `env(VAR)`, `env(VAR, "default")`
+- **Objects**: `{ id: "alice", balance: 100 }`
+- **Arrays**: `[1, 2, 3]`
+- **Operators**: `==`, `!=`, `>`, `<`, `>=`, `<=`, `+`, `-`, `*`, `&&`, `||`, `!`
+- **Functions**: `len(expr)`
+- **Conditionals**: `if condition then expr else expr` — condition must evaluate to bool, returns the then-branch or else-branch value. Nesting is supported with parentheses: `if a then (if b then x else y) else z`
+
 ### Plugin Definition
 
 ```

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -364,9 +364,26 @@ func (c *evalCtx) eval(expr parser.Expr) (any, bool) {
 		return exists, true
 	case parser.UnaryOp:
 		return c.evalUnary(e)
+	case parser.IfExpr:
+		return c.evalIf(e)
 	default:
 		return nil, false
 	}
+}
+
+func (c *evalCtx) evalIf(e parser.IfExpr) (any, bool) {
+	cond, ok := c.eval(e.Condition)
+	if !ok {
+		return nil, false
+	}
+	b, isBool := cond.(bool)
+	if !isBool {
+		return nil, false
+	}
+	if b {
+		return c.eval(e.Then)
+	}
+	return c.eval(e.Else)
 }
 
 func (c *evalCtx) evalUnary(e parser.UnaryOp) (any, bool) {

--- a/pkg/generator/if_test.go
+++ b/pkg/generator/if_test.go
@@ -1,0 +1,152 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/bamsammich/speclang/v2/pkg/parser"
+)
+
+func TestEvalIfExpr_TrueBranch(t *testing.T) {
+	t.Parallel()
+
+	expr := parser.IfExpr{
+		Condition: parser.LiteralBool{Value: true},
+		Then:      parser.LiteralInt{Value: 42},
+		Else:      parser.LiteralInt{Value: 0},
+	}
+	vars := map[string]any{}
+	val, ok := Eval(expr, vars)
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != 42 {
+		t.Errorf("expected 42, got %v", val)
+	}
+}
+
+func TestEvalIfExpr_FalseBranch(t *testing.T) {
+	t.Parallel()
+
+	expr := parser.IfExpr{
+		Condition: parser.LiteralBool{Value: false},
+		Then:      parser.LiteralInt{Value: 42},
+		Else:      parser.LiteralInt{Value: 0},
+	}
+	vars := map[string]any{}
+	val, ok := Eval(expr, vars)
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != 0 {
+		t.Errorf("expected 0, got %v", val)
+	}
+}
+
+func TestEvalIfExpr_ConditionFromExpression(t *testing.T) {
+	t.Parallel()
+
+	// if x > 10 then x - 10 else 0
+	expr := parser.IfExpr{
+		Condition: parser.BinaryOp{
+			Left: parser.FieldRef{Path: "x"}, Op: ">", Right: parser.LiteralInt{Value: 10},
+		},
+		Then: parser.BinaryOp{
+			Left: parser.FieldRef{Path: "x"}, Op: "-", Right: parser.LiteralInt{Value: 10},
+		},
+		Else: parser.LiteralInt{Value: 0},
+	}
+
+	// x = 25 → should take then branch: 25 - 10 = 15
+	val, ok := Eval(expr, map[string]any{"x": 25})
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != 15 {
+		t.Errorf("expected 15, got %v", val)
+	}
+
+	// x = 5 → should take else branch: 0
+	val, ok = Eval(expr, map[string]any{"x": 5})
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != 0 {
+		t.Errorf("expected 0, got %v", val)
+	}
+}
+
+func TestEvalIfExpr_Nested(t *testing.T) {
+	t.Parallel()
+
+	// if a then (if b then 1 else 2) else 3
+	expr := parser.IfExpr{
+		Condition: parser.FieldRef{Path: "a"},
+		Then: parser.IfExpr{
+			Condition: parser.FieldRef{Path: "b"},
+			Then:      parser.LiteralInt{Value: 1},
+			Else:      parser.LiteralInt{Value: 2},
+		},
+		Else: parser.LiteralInt{Value: 3},
+	}
+
+	tests := []struct {
+		a, b bool
+		want int
+	}{
+		{true, true, 1},
+		{true, false, 2},
+		{false, true, 3},
+		{false, false, 3},
+	}
+
+	for _, tt := range tests {
+		val, ok := Eval(expr, map[string]any{"a": tt.a, "b": tt.b})
+		if !ok {
+			t.Fatalf("eval failed for a=%v, b=%v", tt.a, tt.b)
+		}
+		if val != tt.want {
+			t.Errorf("a=%v, b=%v: expected %d, got %v", tt.a, tt.b, tt.want, val)
+		}
+	}
+}
+
+func TestEvalIfExpr_NonBoolCondition(t *testing.T) {
+	t.Parallel()
+
+	expr := parser.IfExpr{
+		Condition: parser.LiteralInt{Value: 1},
+		Then:      parser.LiteralInt{Value: 42},
+		Else:      parser.LiteralInt{Value: 0},
+	}
+	_, ok := Eval(expr, map[string]any{})
+	if ok {
+		t.Error("expected eval to fail for non-bool condition")
+	}
+}
+
+func TestEvalIfExpr_StringBranches(t *testing.T) {
+	t.Parallel()
+
+	// if flag then "yes" else "no"
+	expr := parser.IfExpr{
+		Condition: parser.FieldRef{Path: "flag"},
+		Then:      parser.LiteralString{Value: "yes"},
+		Else:      parser.LiteralString{Value: "no"},
+	}
+
+	val, ok := Eval(expr, map[string]any{"flag": true})
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != "yes" {
+		t.Errorf("expected yes, got %v", val)
+	}
+
+	val, ok = Eval(expr, map[string]any{"flag": false})
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != "no" {
+		t.Errorf("expected no, got %v", val)
+	}
+}

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -203,6 +203,12 @@ type RegexLiteral struct {
 	Pattern string `json:"pattern"`
 }
 
+type IfExpr struct {
+	Condition Expr `json:"condition"`
+	Then      Expr `json:"then"`
+	Else      Expr `json:"else"`
+}
+
 func (LiteralInt) exprNode()    {}
 func (LiteralFloat) exprNode()  {}
 func (LiteralString) exprNode() {}
@@ -219,3 +225,4 @@ func (ContainsExpr) exprNode()  {}
 func (ExistsExpr) exprNode()    {}
 func (HasKeyExpr) exprNode()    {}
 func (RegexLiteral) exprNode()  {}
+func (IfExpr) exprNode()        {}

--- a/pkg/parser/if_test.go
+++ b/pkg/parser/if_test.go
@@ -1,0 +1,208 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/bamsammich/speclang/v2/pkg/parser"
+)
+
+func TestParseIfExpr_Simple(t *testing.T) {
+	t.Parallel()
+
+	spec, err := parser.Parse(`spec T {
+		scope s {
+			use http
+			invariant i {
+				if x > 0 then x else 0
+			}
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	inv := spec.Scopes[0].Invariants[0]
+	if len(inv.Assertions) != 1 {
+		t.Fatalf("expected 1 assertion, got %d", len(inv.Assertions))
+	}
+
+	ifExpr, ok := inv.Assertions[0].Expr.(parser.IfExpr)
+	if !ok {
+		t.Fatalf("expected IfExpr, got %T", inv.Assertions[0].Expr)
+	}
+
+	// Condition: x > 0
+	binOp, ok := ifExpr.Condition.(parser.BinaryOp)
+	if !ok {
+		t.Fatalf("expected BinaryOp condition, got %T", ifExpr.Condition)
+	}
+	if binOp.Op != ">" {
+		t.Errorf("expected op >, got %q", binOp.Op)
+	}
+
+	// Then branch: x (FieldRef)
+	thenRef, ok := ifExpr.Then.(parser.FieldRef)
+	if !ok {
+		t.Fatalf("expected FieldRef in then branch, got %T", ifExpr.Then)
+	}
+	if thenRef.Path != "x" {
+		t.Errorf("expected then=x, got %q", thenRef.Path)
+	}
+
+	// Else branch: 0
+	elseLit, ok := ifExpr.Else.(parser.LiteralInt)
+	if !ok {
+		t.Fatalf("expected LiteralInt in else branch, got %T", ifExpr.Else)
+	}
+	if elseLit.Value != 0 {
+		t.Errorf("expected else=0, got %d", elseLit.Value)
+	}
+}
+
+func TestParseIfExpr_Nested(t *testing.T) {
+	t.Parallel()
+
+	spec, err := parser.Parse(`spec T {
+		scope s {
+			use http
+			invariant i {
+				if a then (if b then x else y) else z
+			}
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	inv := spec.Scopes[0].Invariants[0]
+	ifExpr, ok := inv.Assertions[0].Expr.(parser.IfExpr)
+	if !ok {
+		t.Fatalf("expected IfExpr, got %T", inv.Assertions[0].Expr)
+	}
+
+	// Condition: a
+	condRef, ok := ifExpr.Condition.(parser.FieldRef)
+	if !ok {
+		t.Fatalf("expected FieldRef condition, got %T", ifExpr.Condition)
+	}
+	if condRef.Path != "a" {
+		t.Errorf("expected condition=a, got %q", condRef.Path)
+	}
+
+	// Then branch: nested if
+	innerIf, ok := ifExpr.Then.(parser.IfExpr)
+	if !ok {
+		t.Fatalf("expected nested IfExpr in then branch, got %T", ifExpr.Then)
+	}
+	innerCond, ok := innerIf.Condition.(parser.FieldRef)
+	if !ok || innerCond.Path != "b" {
+		t.Errorf("expected inner condition=b, got %v", innerIf.Condition)
+	}
+	innerThen, ok := innerIf.Then.(parser.FieldRef)
+	if !ok || innerThen.Path != "x" {
+		t.Errorf("expected inner then=x, got %v", innerIf.Then)
+	}
+	innerElse, ok := innerIf.Else.(parser.FieldRef)
+	if !ok || innerElse.Path != "y" {
+		t.Errorf("expected inner else=y, got %v", innerIf.Else)
+	}
+
+	// Else branch: z
+	elseRef, ok := ifExpr.Else.(parser.FieldRef)
+	if !ok || elseRef.Path != "z" {
+		t.Errorf("expected else=z, got %v", ifExpr.Else)
+	}
+}
+
+func TestParseIfExpr_WithOperators(t *testing.T) {
+	t.Parallel()
+
+	// if/then/else with boolean operators in condition and arithmetic in branches
+	spec, err := parser.Parse(`spec T {
+		scope s {
+			use http
+			invariant i {
+				if error == null then output.balance - input.amount else input.balance
+			}
+		}
+	}`)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	inv := spec.Scopes[0].Invariants[0]
+	ifExpr, ok := inv.Assertions[0].Expr.(parser.IfExpr)
+	if !ok {
+		t.Fatalf("expected IfExpr, got %T", inv.Assertions[0].Expr)
+	}
+
+	// Condition: error == null
+	binOp, ok := ifExpr.Condition.(parser.BinaryOp)
+	if !ok {
+		t.Fatalf("expected BinaryOp condition, got %T", ifExpr.Condition)
+	}
+	if binOp.Op != "==" {
+		t.Errorf("expected op ==, got %q", binOp.Op)
+	}
+
+	// Then branch: output.balance - input.amount (BinaryOp)
+	thenOp, ok := ifExpr.Then.(parser.BinaryOp)
+	if !ok {
+		t.Fatalf("expected BinaryOp in then branch, got %T", ifExpr.Then)
+	}
+	if thenOp.Op != "-" {
+		t.Errorf("expected then op -, got %q", thenOp.Op)
+	}
+}
+
+func TestParseIfExpr_MissingElse(t *testing.T) {
+	t.Parallel()
+
+	_, err := parser.Parse(`spec T {
+		scope s {
+			use http
+			invariant i {
+				if x > 0 then x
+			}
+		}
+	}`)
+	if err == nil {
+		t.Fatal("expected parse error for if without else, got nil")
+	}
+}
+
+func TestParseIfExpr_MissingThen(t *testing.T) {
+	t.Parallel()
+
+	_, err := parser.Parse(`spec T {
+		scope s {
+			use http
+			invariant i {
+				if x > 0 x else 0
+			}
+		}
+	}`)
+	if err == nil {
+		t.Fatal("expected parse error for if without then keyword, got nil")
+	}
+}
+
+func TestLexIfElseKeywords(t *testing.T) {
+	t.Parallel()
+
+	tokens, err := parser.Lex("if then else")
+	if err != nil {
+		t.Fatalf("lex failed: %v", err)
+	}
+
+	// Expect: If, Then, Else, EOF
+	expected := []parser.TokenType{parser.TokenIf, parser.TokenThen, parser.TokenElse, parser.TokenEOF}
+	if len(tokens) != len(expected) {
+		t.Fatalf("expected %d tokens, got %d", len(expected), len(tokens))
+	}
+	for i, want := range expected {
+		if tokens[i].Type != want {
+			t.Errorf("token %d: expected %s, got %s", i, want, tokens[i].Type)
+		}
+	}
+}

--- a/pkg/parser/lexer.go
+++ b/pkg/parser/lexer.go
@@ -54,6 +54,8 @@ const (
 	TokenEnv
 	TokenInclude
 	TokenImport
+	TokenIf
+	TokenElse
 
 	// Symbols
 	TokenLBrace   // {
@@ -117,6 +119,8 @@ var tokenNames = map[TokenType]string{
 	TokenEnv:       "Env",
 	TokenInclude:   "Include",
 	TokenImport:    "Import",
+	TokenIf:        "If",
+	TokenElse:      "Else",
 	TokenLBrace:    "LBrace",
 	TokenRBrace:    "RBrace",
 	TokenLParen:    "LParen",
@@ -176,6 +180,8 @@ var keywords = map[string]TokenType{
 	"env":       TokenEnv,
 	"include":   TokenInclude,
 	"import":    TokenImport,
+	"if":        TokenIf,
+	"else":      TokenElse,
 	"true":      TokenBool,
 	"false":     TokenBool,
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1146,6 +1146,9 @@ func (p *parser) parseAtom() (Expr, error) {
 		}
 		return expr, nil
 
+	case TokenIf:
+		return p.parseIfExpr()
+
 	default:
 		// Built-in functions: len(expr), exists(expr), has_key(expr, key)
 		if tok.Type == TokenIdent && tok.Value == "len" {
@@ -1258,6 +1261,30 @@ func (p *parser) parseHasKeyExpr() (Expr, error) {
 		return nil, err
 	}
 	return HasKeyExpr{Arg: arg, Key: key}, nil
+}
+
+// parseIfExpr parses: if expr then expr else expr
+func (p *parser) parseIfExpr() (Expr, error) {
+	p.advance() // consume "if"
+	cond, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(TokenThen); err != nil {
+		return nil, err
+	}
+	thenExpr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(TokenElse); err != nil {
+		return nil, err
+	}
+	elseExpr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return IfExpr{Condition: cond, Then: thenExpr, Else: elseExpr}, nil
 }
 
 // parseEnvRef parses: env(VAR) or env(VAR, "default")

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -270,7 +270,8 @@ func (v *validator) checkExprType(expr parser.Expr, te parser.TypeExpr, context 
 func isNonLiteral(expr parser.Expr) bool {
 	switch expr.(type) {
 	case parser.FieldRef, parser.BinaryOp, parser.UnaryOp,
-		parser.EnvRef, parser.LenExpr, parser.ContainsExpr, parser.ExistsExpr, parser.HasKeyExpr, parser.RegexLiteral:
+		parser.EnvRef, parser.LenExpr, parser.ContainsExpr, parser.ExistsExpr,
+		parser.HasKeyExpr, parser.RegexLiteral, parser.IfExpr:
 		return true
 	}
 	return false

--- a/skills/author/references/api_reference.md
+++ b/skills/author/references/api_reference.md
@@ -88,6 +88,7 @@ spec <Name> {
   - `contains(haystack, needle)` — returns `bool`. String haystack + string needle: substring check. `[]any` haystack + any needle: element membership check.
   - `exists(expr)` — returns `true` if the path resolves to a value (including `null`), `false` if the path doesn't exist
   - `has_key(expr, "key")` — returns `true` if the map contains the specified key, `false` otherwise
+- **Conditionals**: `if condition then expr else expr` — condition must be bool; returns then-branch or else-branch. Nest with parentheses: `if a then (if b then x else y) else z`
 
 ## Comments
 

--- a/specs/parse.spec
+++ b/specs/parse.spec
@@ -68,6 +68,17 @@ scope parse_valid {
     }
   }
 
+  # Verifies that if/then/else conditional expressions parse correctly.
+  scenario if_expr {
+    given {
+      file: "testdata/self/if_expr.spec"
+    }
+    then {
+      exit_code: 0
+      name: "IfExprTest"
+    }
+  }
+
   # Verifies that playwright spec syntax (locators, @assertions, mixed given) parses.
   scenario playwright_spec {
     given {

--- a/testdata/self/if_expr.spec
+++ b/testdata/self/if_expr.spec
@@ -1,0 +1,20 @@
+spec IfExprTest {
+  scope s {
+    use http
+    config {
+      path: "/test"
+      method: "POST"
+    }
+    contract {
+      input {
+        x: int
+      }
+      output {
+        result: int
+      }
+    }
+    invariant conditional_value {
+      if x > 10 then output.result == x - 10 else output.result == 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `if condition then expr else expr` as an expression form in the spec language
- Condition must evaluate to bool; returns then-branch or else-branch value
- Nesting supported via parentheses: `if a then (if b then x else y) else z`

### Changes
- **Lexer**: Added `if` and `else` as keyword tokens
- **AST**: Added `IfExpr` node with Condition, Then, Else fields
- **Parser**: `if` triggers parsing of condition, `then`, then-expr, `else`, else-expr
- **Evaluator**: Evaluates condition (must be bool), returns appropriate branch
- **Validator**: `IfExpr` treated as non-literal (skips static type checking)
- **Tests**: Parser and evaluator unit tests covering true/false branches, nesting, operators, non-bool error, missing keywords
- **Self-verification**: Added `if_expr.spec` test fixture and parse scenario
- **Docs**: Updated CLAUDE.md expressions section and api_reference.md

## Test plan
- [x] `go test ./... -count=1` passes
- [x] Self-verification passes (`specrun verify specs/speclang.spec`)
- [ ] CI passes

Closes #42