### PR TITLE
feat(expr): add array quantifiers all() and any()

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -310,6 +310,10 @@ func (c *evalCtx) eval(expr parser.Expr) (any, bool) {
 		default:
 			return nil, false
 		}
+	case parser.AllExpr:
+		return c.evalAll(e)
+	case parser.AnyExpr:
+		return c.evalAny(e)
 	case parser.ContainsExpr:
 		haystack, ok := c.eval(e.Haystack)
 		if !ok {
@@ -409,6 +413,71 @@ func (c *evalCtx) evalUnary(e parser.UnaryOp) (any, bool) {
 	default:
 		return nil, false
 	}
+}
+
+// evalAll evaluates all(array, elem => predicate). Short-circuits on first false.
+func (c *evalCtx) evalAll(e parser.AllExpr) (any, bool) {
+	arrVal, ok := c.eval(e.Array)
+	if !ok {
+		return nil, false
+	}
+	arr, ok := arrVal.([]any)
+	if !ok {
+		return nil, false
+	}
+	for _, elem := range arr {
+		inner := c.withBinding(e.BoundVar, elem)
+		val, ok := inner.eval(e.Predicate)
+		if !ok {
+			return nil, false
+		}
+		b, isBool := val.(bool)
+		if !isBool {
+			return nil, false
+		}
+		if !b {
+			return false, true
+		}
+	}
+	return true, true
+}
+
+// evalAny evaluates any(array, elem => predicate). Short-circuits on first true.
+func (c *evalCtx) evalAny(e parser.AnyExpr) (any, bool) {
+	arrVal, ok := c.eval(e.Array)
+	if !ok {
+		return nil, false
+	}
+	arr, ok := arrVal.([]any)
+	if !ok {
+		return nil, false
+	}
+	for _, elem := range arr {
+		inner := c.withBinding(e.BoundVar, elem)
+		val, ok := inner.eval(e.Predicate)
+		if !ok {
+			return nil, false
+		}
+		b, isBool := val.(bool)
+		if !isBool {
+			return nil, false
+		}
+		if b {
+			return true, true
+		}
+	}
+	return false, true
+}
+
+// withBinding returns a new evalCtx with the bound variable added to the input scope.
+// The original input map is not mutated.
+func (c *evalCtx) withBinding(name string, value any) *evalCtx {
+	merged := make(map[string]any, len(c.input)+1)
+	for k, v := range c.input {
+		merged[k] = v
+	}
+	merged[name] = value
+	return &evalCtx{input: merged, fieldName: c.fieldName}
 }
 
 func (c *evalCtx) resolveRef(path string) (any, bool) {

--- a/pkg/generator/quantifier_test.go
+++ b/pkg/generator/quantifier_test.go
@@ -1,0 +1,255 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/bamsammich/speclang/v2/pkg/parser"
+)
+
+func TestEvalAll_AllTrue(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]any{
+		"items": []any{1, 2, 3, 4, 5},
+	}
+	// all(items, x => x > 0)
+	expr := parser.AllExpr{
+		Array:    parser.FieldRef{Path: "items"},
+		BoundVar: "x",
+		Predicate: parser.BinaryOp{
+			Left: parser.FieldRef{Path: "x"}, Op: ">", Right: parser.LiteralInt{Value: 0},
+		},
+	}
+
+	val, ok := Eval(expr, vars)
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != true {
+		t.Errorf("expected true, got %v", val)
+	}
+}
+
+func TestEvalAll_OneFalse(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]any{
+		"items": []any{1, 2, -1, 4, 5},
+	}
+	expr := parser.AllExpr{
+		Array:    parser.FieldRef{Path: "items"},
+		BoundVar: "x",
+		Predicate: parser.BinaryOp{
+			Left: parser.FieldRef{Path: "x"}, Op: ">", Right: parser.LiteralInt{Value: 0},
+		},
+	}
+
+	val, ok := Eval(expr, vars)
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != false {
+		t.Errorf("expected false, got %v", val)
+	}
+}
+
+func TestEvalAll_EmptyArray(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]any{
+		"items": []any{},
+	}
+	expr := parser.AllExpr{
+		Array:    parser.FieldRef{Path: "items"},
+		BoundVar: "x",
+		Predicate: parser.BinaryOp{
+			Left: parser.FieldRef{Path: "x"}, Op: ">", Right: parser.LiteralInt{Value: 0},
+		},
+	}
+
+	val, ok := Eval(expr, vars)
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != true {
+		t.Errorf("expected true for vacuous all on empty array, got %v", val)
+	}
+}
+
+func TestEvalAny_OneTrue(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]any{
+		"items": []any{-1, -2, 3, -4},
+	}
+	expr := parser.AnyExpr{
+		Array:    parser.FieldRef{Path: "items"},
+		BoundVar: "x",
+		Predicate: parser.BinaryOp{
+			Left: parser.FieldRef{Path: "x"}, Op: ">", Right: parser.LiteralInt{Value: 0},
+		},
+	}
+
+	val, ok := Eval(expr, vars)
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != true {
+		t.Errorf("expected true, got %v", val)
+	}
+}
+
+func TestEvalAny_AllFalse(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]any{
+		"items": []any{-1, -2, -3},
+	}
+	expr := parser.AnyExpr{
+		Array:    parser.FieldRef{Path: "items"},
+		BoundVar: "x",
+		Predicate: parser.BinaryOp{
+			Left: parser.FieldRef{Path: "x"}, Op: ">", Right: parser.LiteralInt{Value: 0},
+		},
+	}
+
+	val, ok := Eval(expr, vars)
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != false {
+		t.Errorf("expected false, got %v", val)
+	}
+}
+
+func TestEvalAny_EmptyArray(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]any{
+		"items": []any{},
+	}
+	expr := parser.AnyExpr{
+		Array:    parser.FieldRef{Path: "items"},
+		BoundVar: "x",
+		Predicate: parser.BinaryOp{
+			Left: parser.FieldRef{Path: "x"}, Op: ">", Right: parser.LiteralInt{Value: 0},
+		},
+	}
+
+	val, ok := Eval(expr, vars)
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != false {
+		t.Errorf("expected false for any on empty array, got %v", val)
+	}
+}
+
+func TestEvalNestedQuantifiers(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]any{
+		"matrix": []any{
+			[]any{1, 2, 3},
+			[]any{-1, 5},
+			[]any{0, 10},
+		},
+	}
+	// all(matrix, row => any(row, x => x > 0))
+	expr := parser.AllExpr{
+		Array:    parser.FieldRef{Path: "matrix"},
+		BoundVar: "row",
+		Predicate: parser.AnyExpr{
+			Array:    parser.FieldRef{Path: "row"},
+			BoundVar: "x",
+			Predicate: parser.BinaryOp{
+				Left: parser.FieldRef{Path: "x"}, Op: ">", Right: parser.LiteralInt{Value: 0},
+			},
+		},
+	}
+
+	val, ok := Eval(expr, vars)
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != true {
+		t.Errorf("expected true (every row has at least one positive), got %v", val)
+	}
+}
+
+func TestEvalQuantifier_BoundVarDoesNotLeak(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]any{
+		"items": []any{1, 2, 3},
+	}
+	// Evaluate all() — bound var "x" should not exist after
+	expr := parser.AllExpr{
+		Array:    parser.FieldRef{Path: "items"},
+		BoundVar: "x",
+		Predicate: parser.BinaryOp{
+			Left: parser.FieldRef{Path: "x"}, Op: ">", Right: parser.LiteralInt{Value: 0},
+		},
+	}
+
+	Eval(expr, vars)
+
+	// Verify "x" is not in vars
+	if _, exists := vars["x"]; exists {
+		t.Error("bound variable 'x' leaked into outer scope")
+	}
+}
+
+func TestEvalAll_WithObjectElements(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]any{
+		"scopes": []any{
+			map[string]any{"name": "transfer", "passed": true},
+			map[string]any{"name": "deposit", "passed": true},
+		},
+	}
+	// all(scopes, s => s.passed == true)
+	expr := parser.AllExpr{
+		Array:    parser.FieldRef{Path: "scopes"},
+		BoundVar: "s",
+		Predicate: parser.BinaryOp{
+			Left: parser.FieldRef{Path: "s.passed"}, Op: "==", Right: parser.LiteralBool{Value: true},
+		},
+	}
+
+	val, ok := Eval(expr, vars)
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != true {
+		t.Errorf("expected true, got %v", val)
+	}
+}
+
+func TestEvalAny_WithStringPredicate(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]any{
+		"scopes": []any{
+			map[string]any{"name": "transfer"},
+			map[string]any{"name": "deposit"},
+		},
+	}
+	// any(scopes, s => s.name == "transfer")
+	expr := parser.AnyExpr{
+		Array:    parser.FieldRef{Path: "scopes"},
+		BoundVar: "s",
+		Predicate: parser.BinaryOp{
+			Left: parser.FieldRef{Path: "s.name"}, Op: "==", Right: parser.LiteralString{Value: "transfer"},
+		},
+	}
+
+	val, ok := Eval(expr, vars)
+	if !ok {
+		t.Fatal("eval failed")
+	}
+	if val != true {
+		t.Errorf("expected true, got %v", val)
+	}
+}

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -185,6 +185,20 @@ type LenExpr struct {
 	Arg Expr `json:"arg"`
 }
 
+// AllExpr represents all(array, elem => predicate) — true if predicate holds for every element.
+type AllExpr struct {
+	Array     Expr   `json:"array"`     // expression evaluating to an array
+	BoundVar  string `json:"bound_var"` // loop variable name
+	Predicate Expr   `json:"predicate"` // boolean expression evaluated per element
+}
+
+// AnyExpr represents any(array, elem => predicate) — true if predicate holds for at least one element.
+type AnyExpr struct {
+	Array     Expr   `json:"array"`     // expression evaluating to an array
+	BoundVar  string `json:"bound_var"` // loop variable name
+	Predicate Expr   `json:"predicate"` // boolean expression evaluated per element
+}
+
 type ContainsExpr struct {
 	Haystack Expr `json:"haystack"`
 	Needle   Expr `json:"needle"`
@@ -221,6 +235,8 @@ func (ObjectLiteral) exprNode() {}
 func (ArrayLiteral) exprNode()  {}
 func (EnvRef) exprNode()        {}
 func (LenExpr) exprNode()       {}
+func (AllExpr) exprNode()       {}
+func (AnyExpr) exprNode()       {}
 func (ContainsExpr) exprNode()  {}
 func (ExistsExpr) exprNode()    {}
 func (HasKeyExpr) exprNode()    {}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1150,18 +1150,22 @@ func (p *parser) parseAtom() (Expr, error) {
 		return p.parseIfExpr()
 
 	default:
-		// Built-in functions: len(expr), exists(expr), has_key(expr, key)
-		if tok.Type == TokenIdent && tok.Value == "len" {
-			return p.parseLenExpr()
-		}
-		if tok.Type == TokenIdent && tok.Value == "contains" {
-			return p.parseContainsExpr()
-		}
-		if tok.Type == TokenIdent && tok.Value == "exists" {
-			return p.parseExistsExpr()
-		}
-		if tok.Type == TokenIdent && tok.Value == "has_key" {
-			return p.parseHasKeyExpr()
+		// Built-in functions
+		if tok.Type == TokenIdent {
+			switch tok.Value {
+			case "len":
+				return p.parseLenExpr()
+			case "all":
+				return p.parseQuantifierExpr("all")
+			case "any":
+				return p.parseQuantifierExpr("any")
+			case "contains":
+				return p.parseContainsExpr()
+			case "exists":
+				return p.parseExistsExpr()
+			case "has_key":
+				return p.parseHasKeyExpr()
+			}
 		}
 		if isIdentLike(tok.Type) {
 			return p.parseFieldRefExpr()
@@ -1199,6 +1203,45 @@ func (p *parser) parseLenExpr() (Expr, error) {
 		return nil, err
 	}
 	return LenExpr{Arg: arg}, nil
+}
+
+// parseQuantifierExpr parses: all(expr, ident => expr) or any(expr, ident => expr)
+// The "=>" arrow is lexed as TokenAssign followed by TokenGt.
+func (p *parser) parseQuantifierExpr(name string) (Expr, error) {
+	p.advance() // consume "all" or "any"
+	if _, err := p.expect(TokenLParen); err != nil {
+		return nil, err
+	}
+	arrayExpr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(TokenComma); err != nil {
+		return nil, err
+	}
+	boundVar, err := p.expectIdent()
+	if err != nil {
+		return nil, err
+	}
+	// Expect "=>" as two tokens: = then >
+	if _, err := p.expect(TokenAssign); err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(TokenGt); err != nil {
+		return nil, err
+	}
+	predicate, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := p.expect(TokenRParen); err != nil {
+		return nil, err
+	}
+
+	if name == "all" {
+		return AllExpr{Array: arrayExpr, BoundVar: boundVar.Value, Predicate: predicate}, nil
+	}
+	return AnyExpr{Array: arrayExpr, BoundVar: boundVar.Value, Predicate: predicate}, nil
 }
 
 // parseContainsExpr parses: contains(haystack, needle)

--- a/pkg/parser/quantifier_test.go
+++ b/pkg/parser/quantifier_test.go
@@ -1,0 +1,167 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/bamsammich/speclang/v2/pkg/parser"
+)
+
+func TestParseAllExpr(t *testing.T) {
+	t.Parallel()
+
+	src := `spec T {
+  scope s {
+    use http
+    config { path: "/x" method: "GET" }
+    contract {
+      input { items: []int }
+      output { ok: bool }
+    }
+    invariant all_positive {
+      all(input.items, x => x > 0)
+    }
+  }
+}`
+	spec, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	inv := spec.Scopes[0].Invariants[0]
+	if inv.Name != "all_positive" {
+		t.Fatalf("expected invariant name 'all_positive', got %q", inv.Name)
+	}
+
+	a := inv.Assertions[0]
+	allExpr, ok := a.Expr.(parser.AllExpr)
+	if !ok {
+		t.Fatalf("expected AllExpr, got %T", a.Expr)
+	}
+	if allExpr.BoundVar != "x" {
+		t.Errorf("expected bound var 'x', got %q", allExpr.BoundVar)
+	}
+
+	ref, ok := allExpr.Array.(parser.FieldRef)
+	if !ok {
+		t.Fatalf("expected FieldRef for array, got %T", allExpr.Array)
+	}
+	if ref.Path != "input.items" {
+		t.Errorf("expected array path 'input.items', got %q", ref.Path)
+	}
+
+	binOp, ok := allExpr.Predicate.(parser.BinaryOp)
+	if !ok {
+		t.Fatalf("expected BinaryOp for predicate, got %T", allExpr.Predicate)
+	}
+	if binOp.Op != ">" {
+		t.Errorf("expected op '>', got %q", binOp.Op)
+	}
+}
+
+func TestParseAnyExpr(t *testing.T) {
+	t.Parallel()
+
+	src := `spec T {
+  scope s {
+    use http
+    config { path: "/x" method: "GET" }
+    contract {
+      input { items: []string }
+      output { ok: bool }
+    }
+    invariant has_nonempty {
+      any(input.items, s => len(s) > 0)
+    }
+  }
+}`
+	spec, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	inv := spec.Scopes[0].Invariants[0]
+	anyExpr, ok := inv.Assertions[0].Expr.(parser.AnyExpr)
+	if !ok {
+		t.Fatalf("expected AnyExpr, got %T", inv.Assertions[0].Expr)
+	}
+	if anyExpr.BoundVar != "s" {
+		t.Errorf("expected bound var 's', got %q", anyExpr.BoundVar)
+	}
+}
+
+func TestParseNestedQuantifiers(t *testing.T) {
+	t.Parallel()
+
+	src := `spec T {
+  scope s {
+    use http
+    config { path: "/x" method: "GET" }
+    contract {
+      input { matrix: []any }
+      output { ok: bool }
+    }
+    invariant all_rows_have_positive {
+      all(input.matrix, row => any(row, x => x > 0))
+    }
+  }
+}`
+	spec, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	inv := spec.Scopes[0].Invariants[0]
+	allExpr, ok := inv.Assertions[0].Expr.(parser.AllExpr)
+	if !ok {
+		t.Fatalf("expected AllExpr, got %T", inv.Assertions[0].Expr)
+	}
+	if allExpr.BoundVar != "row" {
+		t.Errorf("expected bound var 'row', got %q", allExpr.BoundVar)
+	}
+
+	// Predicate should be AnyExpr
+	anyExpr, ok := allExpr.Predicate.(parser.AnyExpr)
+	if !ok {
+		t.Fatalf("expected nested AnyExpr, got %T", allExpr.Predicate)
+	}
+	if anyExpr.BoundVar != "x" {
+		t.Errorf("expected inner bound var 'x', got %q", anyExpr.BoundVar)
+	}
+}
+
+func TestParseQuantifierWithComplexPredicate(t *testing.T) {
+	t.Parallel()
+
+	src := `spec T {
+  scope s {
+    use http
+    config { path: "/x" method: "GET" }
+    contract {
+      input { nums: []int }
+      output { ok: bool }
+    }
+    invariant bounded {
+      all(input.nums, n => n >= 0 && n <= 100)
+    }
+  }
+}`
+	spec, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	inv := spec.Scopes[0].Invariants[0]
+	allExpr, ok := inv.Assertions[0].Expr.(parser.AllExpr)
+	if !ok {
+		t.Fatalf("expected AllExpr, got %T", inv.Assertions[0].Expr)
+	}
+
+	// Predicate should be a && BinaryOp
+	binOp, ok := allExpr.Predicate.(parser.BinaryOp)
+	if !ok {
+		t.Fatalf("expected BinaryOp for predicate, got %T", allExpr.Predicate)
+	}
+	if binOp.Op != "&&" {
+		t.Errorf("expected op '&&', got %q", binOp.Op)
+	}
+}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -270,8 +270,9 @@ func (v *validator) checkExprType(expr parser.Expr, te parser.TypeExpr, context 
 func isNonLiteral(expr parser.Expr) bool {
 	switch expr.(type) {
 	case parser.FieldRef, parser.BinaryOp, parser.UnaryOp,
-		parser.EnvRef, parser.LenExpr, parser.ContainsExpr, parser.ExistsExpr,
-		parser.HasKeyExpr, parser.RegexLiteral, parser.IfExpr:
+		parser.EnvRef, parser.LenExpr, parser.AllExpr, parser.AnyExpr,
+		parser.ContainsExpr, parser.ExistsExpr, parser.HasKeyExpr,
+		parser.RegexLiteral, parser.IfExpr:
 		return true
 	}
 	return false

--- a/skills/author/SKILL.md
+++ b/skills/author/SKILL.md
@@ -89,6 +89,18 @@ invariant conservation {
 }
 ```
 
+Use `all()` and `any()` to assert over array elements:
+
+```
+invariant all_items_valid {
+  all(output.items, item => item.status != "error")
+}
+
+invariant has_primary {
+  any(output.items, item => item.primary == true)
+}
+```
+
 For UI specs, invariants over visible state are also useful:
 
 ```

--- a/skills/author/references/api_reference.md
+++ b/skills/author/references/api_reference.md
@@ -85,6 +85,8 @@ spec <Name> {
 - **Operators**: `==`, `!=`, `>`, `<`, `>=`, `<=`, `+`, `-`, `*`, `/`, `%`, `&&`, `||`, `!`
 - **Functions**:
   - `len(expr)` — returns length of array, map, or string
+  - `all(array, elem => predicate)` — true if predicate holds for every element
+  - `any(array, elem => predicate)` — true if predicate holds for at least one element
   - `contains(haystack, needle)` — returns `bool`. String haystack + string needle: substring check. `[]any` haystack + any needle: element membership check.
   - `exists(expr)` — returns `true` if the path resolves to a value (including `null`), `false` if the path doesn't exist
   - `has_key(expr, "key")` — returns `true` if the map contains the specified key, `false` otherwise

--- a/specs/parse.spec
+++ b/specs/parse.spec
@@ -89,6 +89,17 @@ scope parse_valid {
       name: "LoginUI"
     }
   }
+
+  # Verifies that all() and any() quantifier expressions parse.
+  scenario quantifier_spec {
+    given {
+      file: "testdata/self/quantifiers.spec"
+    }
+    then {
+      exit_code: 0
+      name: "Quantifiers"
+    }
+  }
 }
 
 # Verifies the parser rejects malformed specs with a non-zero exit code.

--- a/specs/verify.spec
+++ b/specs/verify.spec
@@ -32,4 +32,16 @@ scope verify_pass {
       invariants_passed: 3
     }
   }
+
+  # Every scope in the verify JSON has a non-empty name.
+  invariant all_scopes_have_names {
+    when exit_code == 0:
+      all(output.scopes, s => s.name != "")
+  }
+
+  # Every check across all scopes passes.
+  invariant all_checks_pass {
+    when exit_code == 0:
+      all(output.scopes, s => all(s.checks, c => c.passed == true))
+  }
 }

--- a/testdata/self/quantifiers.spec
+++ b/testdata/self/quantifiers.spec
@@ -1,0 +1,23 @@
+spec Quantifiers {
+  scope items {
+    use http
+    config {
+      path: "/items"
+      method: "GET"
+    }
+    contract {
+      input {
+        ids: []int
+      }
+      output {
+        results: any
+      }
+    }
+    invariant all_positive {
+      all(input.ids, x => x > 0)
+    }
+    invariant any_large {
+      any(input.ids, x => x > 100)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `all(array, elem => predicate)` and `any(array, elem => predicate)` expression forms for asserting properties over array elements
- Parser handles `=>` lambda syntax (lexed as `=` + `>` token pair)
- Evaluator iterates arrays with short-circuiting and scoped bound variables
- Self-verification specs use nested quantifiers to assert on verify JSON output (e.g., `all(scopes, s => all(s.checks, c => c.passed == true))`)

## Test plan

- [x] Unit tests for parsing: basic all/any, nested quantifiers, complex predicates
- [x] Unit tests for evaluation: all-true, one-false, any-one-true, all-false, empty arrays, nested quantifiers, object elements, bound variable leak check
- [x] `go test ./... -count=1` passes
- [x] Self-verification passes with new quantifier-based invariants (`all_scopes_have_names`, `all_checks_pass`)
- [ ] CI passes

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)