### PR TITLE
refactor: remove SPECRUN_SVC_PORT_* env var propagation

### DIFF
--- a/cmd/specrun/main.go
+++ b/cmd/specrun/main.go
@@ -325,59 +325,15 @@ func logProgress(jsonOutput bool, format string, args ...any) {
 	}
 }
 
-// svcPortEnvKey returns the env var name used to propagate a running service's
-// URL by port (e.g., "SPECRUN_SVC_PORT_8080" for port 8080).
-func svcPortEnvKey(port int) string {
-	return fmt.Sprintf("SPECRUN_SVC_PORT_%d", port)
-}
-
-// inheritedServiceURL returns the URL of a service already started by a parent
-// specrun process, identified by declared port. Returns "" if not inherited.
-func inheritedServiceURL(port int) string {
-	return os.Getenv(svcPortEnvKey(port))
-}
-
-// resolveInheritedServices checks if ALL declared services have URLs inherited
-// from a parent specrun process (via SPECRUN_SVC_PORT_* env vars). Returns
-// RunningService entries if all are inherited, nil otherwise.
-func resolveInheritedServices(
-	defs []infra.ServiceDef,
-) []infra.RunningService {
-	if len(defs) == 0 {
-		return nil
-	}
-	var services []infra.RunningService
-	for _, def := range defs {
-		url := inheritedServiceURL(def.Port)
-		if url == "" {
-			return nil
-		}
-		services = append(services, infra.RunningService{
-			Name: def.Name,
-			URL:  url,
-			Port: def.Port,
-		})
-	}
-	return services
-}
-
 // startServices builds infra config, starts services if declared, and returns
 // running services and a cleanup function. The cleanup function is nil when
 // no services are running or --keep-services is set.
-// Services already started by a parent specrun process (identified by
-// SPECRUN_SVC_PORT_* env vars) are reused without starting new containers.
 func startServices(
 	ctx context.Context,
 	s *spec.Spec,
 	opts *verifyOpts,
 ) ([]infra.RunningService, func(), error) {
 	cfg := buildInfraConfig(s, opts.specFile)
-
-	// Check if all declared services are already provided by a parent process.
-	inherited := resolveInheritedServices(cfg.Services)
-	if inherited != nil {
-		return inherited, nil, nil
-	}
 
 	manager, err := infra.NewManager(cfg)
 	if err != nil {
@@ -397,13 +353,6 @@ func startServices(
 	services, err := manager.Start(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("service start error: %w", err)
-	}
-
-	// Propagate service URLs by port to child processes so nested specrun
-	// invocations reuse the already-running containers.
-	for _, svc := range services {
-		//nolint:errcheck // env propagation is best-effort
-		os.Setenv(svcPortEnvKey(svc.Port), svc.URL)
 	}
 
 	for _, svc := range services {
@@ -603,14 +552,13 @@ func resolveTargetConfig(
 		return config
 	}
 	for key, expr := range target.Fields {
-		config[key] = resolveExprToString(expr, target, services)
+		config[key] = resolveExprToString(expr, services)
 	}
 	return config
 }
 
 func resolveExprToString(
 	expr spec.Expr,
-	target *spec.Target,
 	services []infra.RunningService,
 ) string {
 	switch e := expr.(type) {
@@ -622,33 +570,20 @@ func resolveExprToString(
 		}
 		return e.Default
 	case spec.ServiceRef:
-		return resolveServiceURL(e.Name, target, services)
+		return resolveServiceURL(e.Name, services)
 	default:
 		return fmt.Sprintf("%v", e)
 	}
 }
 
-// resolveServiceURL finds the URL for a named service. It checks running
-// services first, then checks SPECRUN_SVC_PORT_* env vars (set by a parent
-// specrun process that started the container on a declared port).
+// resolveServiceURL finds the URL for a named service from running services.
 func resolveServiceURL(
 	name string,
-	target *spec.Target,
 	services []infra.RunningService,
 ) string {
 	for _, svc := range services {
 		if svc.Name == name {
 			return svc.URL
-		}
-	}
-	// Check if a parent process started a container on this service's port.
-	if target != nil {
-		for _, svc := range target.Services {
-			if svc.Name == name && svc.Port > 0 {
-				if url := inheritedServiceURL(svc.Port); url != "" {
-					return url
-				}
-			}
 		}
 	}
 	return ""

--- a/internal/infra/docker.go
+++ b/internal/infra/docker.go
@@ -126,6 +126,15 @@ func (dm *DockerManager) Cleanup(ctx context.Context) error {
 }
 
 func (dm *DockerManager) startService(ctx context.Context, svc ServiceDef) (RunningService, error) {
+	// If the declared port is already listening and healthy, reuse it.
+	// This handles nested specrun invocations where a parent process already
+	// started a container on the same port.
+	if svc.Port > 0 {
+		if rs, ok := adoptExistingPort(svc); ok {
+			return rs, nil
+		}
+	}
+
 	if err := dm.ensureImage(ctx, svc); err != nil {
 		return RunningService{}, err
 	}
@@ -179,6 +188,28 @@ func (dm *DockerManager) startService(ctx context.Context, svc ServiceDef) (Runn
 		URL:  fmt.Sprintf("http://localhost:%d", port),
 		Port: port,
 	}, nil
+}
+
+// adoptExistingPort checks if the declared port already has a healthy listener.
+// If so, returns a RunningService pointing at it. This allows nested specrun
+// invocations to reuse containers started by a parent process without needing
+// env var propagation.
+func adoptExistingPort(svc ServiceDef) (RunningService, bool) {
+	healthy := false
+	if svc.Health != "" {
+		healthy = httpHealthCheck(svc.Port, svc.Health)
+	} else {
+		healthy = tcpHealthCheck(svc.Port)
+	}
+	if !healthy {
+		return RunningService{}, false
+	}
+
+	return RunningService{
+		Name: svc.Name,
+		URL:  fmt.Sprintf("http://localhost:%d", svc.Port),
+		Port: svc.Port,
+	}, true
 }
 
 func (dm *DockerManager) ensureImage(ctx context.Context, svc ServiceDef) error {


### PR DESCRIPTION
## Summary

Closes #79

- Removed `svcPortEnvKey()`, `inheritedServiceURL()`, `resolveInheritedServices()` from `cmd/specrun/main.go`
- Removed `SPECRUN_SVC_PORT_*` env var propagation loop in `startServices()`
- Removed port-based fallback in `resolveServiceURL()`
- Simplified `resolveExprToString()` by dropping unnecessary `target` parameter
- Added `adoptExistingPort()` in `internal/infra/docker.go` — checks if the declared port is already healthy before starting a container, handling nested invocations at the infra layer

Net -34 lines.

## Test plan

- [x] `go build ./cmd/specrun` — exit 0
- [x] `golangci-lint run ./cmd/specrun/ ./internal/infra/` — 0 issues
- [x] `go test -count=1 ./...` — all pass (except transient Docker Hub 502 in unrelated `TestDockerManager_Cleanup`)
- [x] No remaining references to `SPECRUN_SVC_PORT`, `svcPortEnvKey`, `inheritedServiceURL`, or `resolveInheritedServices`