### PR TITLE
fix(parser): accept numeric dot-path segments and keyword field names

### DIFF
--- a/internal/generator/array_index_ref_test.go
+++ b/internal/generator/array_index_ref_test.go
@@ -1,0 +1,98 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/bamsammich/speclang/v2/internal/parser"
+)
+
+func TestResolveRef_ArrayIndex(t *testing.T) {
+	t.Parallel()
+
+	ctx := &evalCtx{
+		input: map[string]any{
+			"items": []any{"first", "second", "third"},
+		},
+	}
+
+	val, ok := ctx.resolveRef("items.0")
+	if !ok {
+		t.Fatal("resolveRef returned ok=false for items.0")
+	}
+	if val != "first" {
+		t.Errorf("items.0 = %v, want %q", val, "first")
+	}
+
+	val, ok = ctx.resolveRef("items.2")
+	if !ok {
+		t.Fatal("resolveRef returned ok=false for items.2")
+	}
+	if val != "third" {
+		t.Errorf("items.2 = %v, want %q", val, "third")
+	}
+}
+
+func TestResolveRef_NestedArrayIndex(t *testing.T) {
+	t.Parallel()
+
+	ctx := &evalCtx{
+		input: map[string]any{
+			"results": []any{
+				map[string]any{"name": "alice"},
+				map[string]any{"name": "bob"},
+			},
+		},
+	}
+
+	val, ok := ctx.resolveRef("results.0.name")
+	if !ok {
+		t.Fatal("resolveRef returned ok=false for results.0.name")
+	}
+	if val != "alice" {
+		t.Errorf("results.0.name = %v, want %q", val, "alice")
+	}
+
+	val, ok = ctx.resolveRef("results.1.name")
+	if !ok {
+		t.Fatal("resolveRef returned ok=false for results.1.name")
+	}
+	if val != "bob" {
+		t.Errorf("results.1.name = %v, want %q", val, "bob")
+	}
+}
+
+func TestResolveRef_ArrayIndexOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	ctx := &evalCtx{
+		input: map[string]any{
+			"items": []any{"only"},
+		},
+	}
+
+	_, ok := ctx.resolveRef("items.5")
+	if ok {
+		t.Error("expected ok=false for out-of-range index")
+	}
+
+	_, ok = ctx.resolveRef("items.-1")
+	if ok {
+		t.Error("expected ok=false for negative index")
+	}
+}
+
+func TestEval_FieldRef_ArrayIndex(t *testing.T) {
+	t.Parallel()
+
+	val, ok := Eval(parser.FieldRef{Path: "output.items.0"}, map[string]any{
+		"output": map[string]any{
+			"items": []any{"alpha", "beta"},
+		},
+	})
+	if !ok {
+		t.Fatal("Eval returned ok=false for output.items.0")
+	}
+	if val != "alpha" {
+		t.Errorf("output.items.0 = %v, want %q", val, "alpha")
+	}
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -8,6 +8,7 @@ import (
 	"math/rand/v2" //nolint:gosec // intentional use of math/rand for reproducible test generation
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/bamsammich/speclang/v2/internal/parser"
@@ -533,15 +534,22 @@ func (c *evalCtx) resolveRef(path string) (any, bool) {
 	var current any = c.input
 
 	for _, part := range parts {
-		m, ok := current.(map[string]any)
-		if !ok {
+		switch v := current.(type) {
+		case map[string]any:
+			val, exists := v[part]
+			if !exists {
+				return nil, false
+			}
+			current = val
+		case []any:
+			idx, err := strconv.Atoi(part)
+			if err != nil || idx < 0 || idx >= len(v) {
+				return nil, false
+			}
+			current = v[idx]
+		default:
 			return nil, false
 		}
-		val, exists := m[part]
-		if !exists {
-			return nil, false
-		}
-		current = val
 	}
 
 	return current, true

--- a/internal/parser/array_index_expr_test.go
+++ b/internal/parser/array_index_expr_test.go
@@ -1,0 +1,124 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestParseFieldRefExpr_ArrayIndex(t *testing.T) {
+	t.Parallel()
+
+	spec, err := Parse(`
+spec Test {
+  scope test_scope {
+    use http
+    config {
+      path: "/test"
+      method: "GET"
+    }
+    contract {
+      input {}
+      output {
+        items: []string
+        error: string?
+      }
+    }
+    invariant order {
+      when error == null && len(output.items) > 1:
+        output.items.0 >= output.items.1
+    }
+  }
+}
+`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	inv := spec.Scopes[0].Invariants[0]
+	if inv.Name != "order" {
+		t.Errorf("invariant name = %q, want %q", inv.Name, "order")
+	}
+
+	if len(inv.Assertions) == 0 {
+		t.Fatal("expected at least one assertion in invariant")
+	}
+}
+
+func TestParseFieldRefExpr_NestedArrayIndex(t *testing.T) {
+	t.Parallel()
+
+	spec, err := Parse(`
+spec Test {
+  model Item { name: string }
+  scope test_scope {
+    use http
+    config {
+      path: "/test"
+      method: "GET"
+    }
+    contract {
+      input {}
+      output {
+        results: []Item
+        error: string?
+      }
+    }
+    invariant first_name {
+      when error == null && len(output.results) > 0:
+        output.results.0.name != ""
+    }
+  }
+}
+`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	inv := spec.Scopes[0].Invariants[0]
+	if len(inv.Assertions) == 0 {
+		t.Fatal("expected at least one assertion")
+	}
+}
+
+func TestParseField_KeywordAsFieldName(t *testing.T) {
+	t.Parallel()
+
+	spec, err := Parse(`
+spec Test {
+  scope test_scope {
+    use http
+    config {
+      path: "/test"
+      method: "GET"
+    }
+    contract {
+      input {}
+      output {
+        action: string
+        model: string
+        input: int
+        output: int
+        target: string
+        scope: string
+        config: string
+        given: bool
+        then: bool
+      }
+    }
+  }
+}
+`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	fields := spec.Scopes[0].Contract.Output
+	expected := []string{"action", "model", "input", "output", "target", "scope", "config", "given", "then"}
+	if len(fields) != len(expected) {
+		t.Fatalf("expected %d output fields, got %d", len(expected), len(fields))
+	}
+	for i, name := range expected {
+		if fields[i].Name != name {
+			t.Errorf("field %d: name = %q, want %q", i, fields[i].Name, name)
+		}
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -613,7 +613,7 @@ func (p *parser) parseModel() (*Model, error) {
 
 // parseField parses: name: type {constraint}?
 func (p *parser) parseField() (*Field, error) {
-	name, err := p.expect(TokenIdent)
+	name, err := p.expectIdent()
 	if err != nil {
 		return nil, err
 	}
@@ -1388,6 +1388,12 @@ func (p *parser) parseFieldRefExpr() (Expr, error) {
 	path := first.Value
 	for p.peek().Type == TokenDot {
 		p.advance() // consume .
+		// Accept integer tokens as array index segments (e.g., "output.items.0").
+		if p.peek().Type == TokenInt {
+			seg := p.advance()
+			path += "." + seg.Value
+			continue
+		}
 		next, err := p.expectIdent()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary
- **Array index in expressions**: `parseFieldRefExpr()` now accepts `TokenInt` segments after `.` (e.g., `output.items.0`), matching how `parseFieldPath()` already handled them in `then`-block assertions
- **Keyword field names**: `parseField()` now uses `expectIdent()` instead of `expect(TokenIdent)`, so keywords like `action`, `model`, `input`, etc. work as contract field names
- **Generator array traversal**: `resolveRef()` now handles `[]any` slices via `strconv.Atoi`, so array indexing works in `when`/invariant constraint evaluation

Fixes #88

## Test plan
- [x] Parser test: spec with `output.items.0` in an invariant parses successfully
- [x] Parser test: nested array index (`results.0.name`) parses successfully
- [x] Parser test: all keyword tokens accepted as contract field names
- [x] Generator test: `resolveRef` resolves numeric segments against `[]any`
- [x] Generator test: out-of-range and negative indices return `ok=false`
- [x] Generator test: `Eval` with `FieldRef` containing array index works end-to-end
- [x] Full test suite passes (`go test ./...`)