### PR TITLE
feat(parser): support comparison operators in then-block assertions

### DIFF
--- a/docs/language-reference.md
+++ b/docs/language-reference.md
@@ -477,13 +477,26 @@ given {
 
 ### Plain Assertions
 
-In `then` blocks, assert output field values:
+In `then` blocks, assert output field values. `:` is sugar for equality (`==`):
 
 ```
 then {
   status: 200
   from.balance: from.balance - amount
   error: null
+}
+```
+
+### Comparison Operators
+
+Assertions support comparison operators (`==`, `!=`, `>`, `>=`, `<`, `<=`). `:` is equivalent to `==`. Relational operators (`>`, `>=`, `<`, `<=`) require numeric values.
+
+```
+then {
+  status: 200                        # equality (: is sugar for ==)
+  items@playwright.count >= 1        # relational
+  score != 0                         # inequality
+  from.balance <= from.balance       # relational on fields
 }
 ```
 
@@ -496,6 +509,7 @@ then {
   welcome@playwright.visible: true
   welcome@playwright.text: "Welcome, alice"
   error_msg@playwright.visible: false
+  items@playwright.count >= 1
 }
 ```
 

--- a/internal/parser/assertion_test.go
+++ b/internal/parser/assertion_test.go
@@ -82,4 +82,74 @@ spec Test {
 			a.Property,
 		)
 	}
+	if a.Operator != "==" {
+		t.Errorf("colon assertion Operator = %q, want '=='", a.Operator)
+	}
+}
+
+func TestParseThenBlock_ComparisonOperators(t *testing.T) {
+	t.Parallel()
+	spec, err := Parse(`
+spec Test {
+  locators {
+    items: [data-testid=items]
+  }
+  scope test {
+    use playwright
+    contract {
+      input { x: int }
+      output { score: int }
+    }
+    scenario ops {
+      given { x: 1 }
+      then {
+        items@playwright.count >= 1
+        items@playwright.count > 0
+        items@playwright.count <= 100
+        items@playwright.count < 101
+        score != 0
+        score == 42
+      }
+    }
+  }
+}
+`)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	assertions := spec.Scopes[0].Scenarios[0].Then.Assertions
+
+	if len(assertions) != 6 {
+		t.Fatalf("expected 6 assertions, got %d", len(assertions))
+	}
+
+	tests := []struct {
+		target   string
+		plugin   string
+		property string
+		operator string
+	}{
+		{"items", "playwright", "count", ">="},
+		{"items", "playwright", "count", ">"},
+		{"items", "playwright", "count", "<="},
+		{"items", "playwright", "count", "<"},
+		{"score", "", "", "!="},
+		{"score", "", "", "=="},
+	}
+
+	for i, tt := range tests {
+		a := assertions[i]
+		if a.Target != tt.target {
+			t.Errorf("assertion[%d] Target = %q, want %q", i, a.Target, tt.target)
+		}
+		if a.Plugin != tt.plugin {
+			t.Errorf("assertion[%d] Plugin = %q, want %q", i, a.Plugin, tt.plugin)
+		}
+		if a.Property != tt.property {
+			t.Errorf("assertion[%d] Property = %q, want %q", i, a.Property, tt.property)
+		}
+		if a.Operator != tt.operator {
+			t.Errorf("assertion[%d] Operator = %q, want %q", i, a.Operator, tt.operator)
+		}
+	}
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1137,9 +1137,20 @@ func (p *parser) parseAssertion() (*Assertion, error) {
 		a.Property = property.Value
 	}
 
-	if _, err := p.expect(TokenColon); err != nil {
-		return nil, err
+	// Accept ':' (sugar for ==) or a comparison operator.
+	op := "=="
+	tok := p.peek()
+	switch tok.Type {
+	case TokenColon:
+		p.advance()
+	case TokenGt, TokenGte, TokenLt, TokenLte, TokenEq, TokenNeq:
+		p.advance()
+		op = tok.Value
+	default:
+		return nil, p.errAt(tok, "expected ':' or comparison operator in assertion")
 	}
+	a.Operator = op
+
 	val, err := p.parseExpr()
 	if err != nil {
 		return nil, err

--- a/internal/runner/compare_test.go
+++ b/internal/runner/compare_test.go
@@ -1,0 +1,60 @@
+package runner
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCompareAssertion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		op       string
+		actual   any
+		expected any
+		want     bool
+	}{
+		{"gt true", ">", 5.0, 3.0, true},
+		{"gt false", ">", 3.0, 5.0, false},
+		{"gt equal", ">", 3.0, 3.0, false},
+		{"gte true", ">=", 5.0, 3.0, true},
+		{"gte equal", ">=", 3.0, 3.0, true},
+		{"gte false", ">=", 2.0, 3.0, false},
+		{"lt true", "<", 1.0, 3.0, true},
+		{"lt false", "<", 5.0, 3.0, false},
+		{"lte true", "<=", 3.0, 3.0, true},
+		{"lte false", "<=", 5.0, 3.0, false},
+		{"neq true", "!=", 1.0, 2.0, true},
+		{"neq false", "!=", 1.0, 1.0, false},
+		{"neq strings", "!=", "a", "b", true},
+		{"neq strings equal", "!=", "a", "a", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actual, _ := json.Marshal(tt.actual)
+			expected, _ := json.Marshal(tt.expected)
+			got, err := compareAssertion(tt.op, actual, expected)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("compareAssertion(%q, %s, %s) = %v, want %v",
+					tt.op, actual, expected, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareAssertion_NonNumericRelational(t *testing.T) {
+	t.Parallel()
+
+	actual, _ := json.Marshal("not a number")
+	expected, _ := json.Marshal(1.0)
+	_, err := compareAssertion(">=", actual, expected)
+	if err == nil {
+		t.Fatal("expected error for non-numeric relational comparison")
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -622,17 +622,80 @@ func (sr *scopeRunner) checkSingleAssertion(
 	if err != nil {
 		return nil, fmt.Errorf("asserting %q: %w", a.Target, err)
 	}
-	if !resp.OK {
+
+	op := a.Operator
+	if op == "" {
+		op = "=="
+	}
+
+	if op == "==" {
+		// Equality: use adapter's built-in comparison.
+		if !resp.OK {
+			return &Failure{
+				Name:        name,
+				Scope:       sr.scope,
+				Input:       input,
+				Expected:    string(expected),
+				Actual:      string(resp.Actual),
+				Description: fmt.Sprintf("assertion %q failed: %s", a.Target, resp.Error),
+			}, nil
+		}
+		return nil, nil
+	}
+
+	// Non-equality operator: compare actual vs expected in the runner.
+	ok, cmpErr := compareAssertion(op, resp.Actual, expected)
+	if cmpErr != nil {
+		return nil, fmt.Errorf("comparing %q with %s: %w", a.Target, op, cmpErr)
+	}
+	if !ok {
 		return &Failure{
 			Name:        name,
 			Scope:       sr.scope,
 			Input:       input,
-			Expected:    string(expected),
+			Expected:    fmt.Sprintf("%s %s", op, string(expected)),
 			Actual:      string(resp.Actual),
-			Description: fmt.Sprintf("assertion %q failed: %s", a.Target, resp.Error),
+			Description: fmt.Sprintf("assertion %q failed: got %s, expected %s %s", a.Target, string(resp.Actual), op, string(expected)),
 		}, nil
 	}
 	return nil, nil
+}
+
+// compareAssertion evaluates a non-equality comparison between actual and expected
+// JSON values. Supports !=, >, >=, <, <=. Relational operators require numeric values.
+func compareAssertion(op string, actual, expected json.RawMessage) (bool, error) {
+	if op == "!=" {
+		var a, e any
+		if err := json.Unmarshal(actual, &a); err != nil {
+			return false, fmt.Errorf("unmarshaling actual: %w", err)
+		}
+		if err := json.Unmarshal(expected, &e); err != nil {
+			return false, fmt.Errorf("unmarshaling expected: %w", err)
+		}
+		return fmt.Sprintf("%v", a) != fmt.Sprintf("%v", e), nil
+	}
+
+	// Relational operators require numeric values.
+	var a, e float64
+	if err := json.Unmarshal(actual, &a); err != nil {
+		return false, fmt.Errorf("operator %s requires numeric actual, got %s", op, string(actual))
+	}
+	if err := json.Unmarshal(expected, &e); err != nil {
+		return false, fmt.Errorf("operator %s requires numeric expected, got %s", op, string(expected))
+	}
+
+	switch op {
+	case ">":
+		return a > e, nil
+	case ">=":
+		return a >= e, nil
+	case "<":
+		return a < e, nil
+	case "<=":
+		return a <= e, nil
+	default:
+		return false, fmt.Errorf("unsupported operator %q", op)
+	}
 }
 
 func (sr *scopeRunner) resolveAssertionTarget(a *parser.Assertion) (string, string, error) {

--- a/pkg/spec/ast.go
+++ b/pkg/spec/ast.go
@@ -130,6 +130,7 @@ type Assertion struct {
 	Target   string `json:"target,omitempty"`   // field path or locator name
 	Plugin   string `json:"plugin,omitempty"`   // plugin namespace (from @ syntax)
 	Property string `json:"property,omitempty"` // assertion property name
+	Operator string `json:"operator,omitempty"` // comparison operator: ==, !=, >, >=, <, <= (default ==)
 }
 
 // Assignment sets a concrete value: field: value

--- a/skills/author/references/api_reference.md
+++ b/skills/author/references/api_reference.md
@@ -207,6 +207,18 @@ then {
 
 This syntax is available to all adapters but is primarily used with `playwright`.
 
+## Comparison Operators in Assertions
+
+Assertions support comparison operators (`==`, `!=`, `>`, `>=`, `<`, `<=`). `:` is sugar for `==`. Relational operators (`>`, `>=`, `<`, `<=`) require numeric values.
+
+```
+then {
+  status: 200                        # equality (: is sugar for ==)
+  items@playwright.count >= 1        # relational
+  score != 0                         # inequality
+}
+```
+
 ## Mixed `given` Block Syntax
 
 `given` blocks accept both **data assignments** and **action calls**, interleaved in any order. Steps execute in the order written. This works with any adapter that supports action calls (Playwright and HTTP).


### PR DESCRIPTION
## Summary
- Assertions in `then` blocks now accept comparison operators (`==`, `!=`, `>`, `>=`, `<`, `<=`) in addition to `:` (which remains sugar for `==`)
- Relational operators (`>`, `>=`, `<`, `<=`) require numeric values; the runner compares actual vs expected itself rather than relying on adapter equality
- Added `Operator` field to the `Assertion` AST node
- Updated language reference and skill docs

Fixes the comparison operator portion of #90. Inline CSS selectors are by design — [commented on the issue](https://github.com/bamsammich/speclang/issues/90#issuecomment-4139754868) with guidance to use `locators {}` blocks.

## Test plan
- [x] Parser: all six operators parse correctly with plugin and plain assertions
- [x] Parser: `:` defaults to `==` operator
- [x] Runner: `compareAssertion()` unit tests for all operators
- [x] Runner: non-numeric values with relational operators produce errors
- [x] Full test suite passes (`go test ./...`)