### PR TITLE
fix(validator): allow plugin-specific assertion targets in then blocks

### DIFF
--- a/cmd/specrun/main.go
+++ b/cmd/specrun/main.go
@@ -188,7 +188,7 @@ func installCmd() *cli.Command {
 }
 
 func validateSpec(s *spec.Spec) int {
-	errs := specrun.Validate(s)
+	errs := specrun.Validate(s, nil)
 	if len(errs) > 0 {
 		//nolint:gosec // CLI writing to stderr, not a web response
 		fmt.Fprint(os.Stderr, specrun.FormatErrors(errs))

--- a/docs/package.md
+++ b/docs/package.md
@@ -112,7 +112,7 @@ Import support:
 |----------|-------------|
 | `Parse(source string)` | Parse a spec from source text |
 | `ParseFile(path string, imports ImportRegistry)` | Parse from file with include/import resolution |
-| `Validate(s *Spec)` | Check for semantic errors (returns `[]error`) |
+| `Validate(s *Spec, registry *Registry)` | Check for semantic errors (returns `[]error`); nil registry uses DefaultRegistry() |
 | `FormatErrors(errs []error)` | Format validation errors for display |
 | `Verify(s *Spec, registry *Registry, opts Options)` | Run full verification pipeline |
 | `Generate(s *Spec, scopeName string, seed uint64)` | Produce one random input for a scope |
@@ -160,7 +160,7 @@ s, err := specrun.Parse(source)
 After parsing, check for semantic errors:
 
 ```go
-errs := specrun.Validate(s)
+errs := specrun.Validate(s, nil) // nil uses DefaultRegistry()
 if len(errs) > 0 {
 	fmt.Fprintln(os.Stderr, specrun.FormatErrors(errs))
 	os.Exit(1)

--- a/internal/validator/enum_test.go
+++ b/internal/validator/enum_test.go
@@ -41,7 +41,7 @@ func TestValidate_EnumValidVariant(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors, got: %v", errs)
 	}
@@ -82,7 +82,7 @@ func TestValidate_EnumInvalidVariant(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 1 {
 		t.Fatalf("expected 1 error for invalid variant, got %d: %v", len(errs), errs)
 	}
@@ -126,7 +126,7 @@ func TestValidate_EnumWrongLiteralType(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 1 {
 		t.Fatalf("expected 1 error for non-string assigned to enum, got %d: %v", len(errs), errs)
 	}
@@ -151,7 +151,7 @@ func TestValidate_EnumInContractPasses(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors, got: %v", errs)
 	}
@@ -190,7 +190,7 @@ func TestValidate_EnumNullForOptional(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors for null on optional enum, got: %v", errs)
 	}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/bamsammich/speclang/v2/internal/parser"
+	"github.com/bamsammich/speclang/v2/pkg/spec"
 )
 
 // primitives are type names that don't need model resolution.
@@ -15,15 +16,17 @@ var primitives = map[string]bool{
 }
 
 // Validate performs post-parse semantic validation on a spec.
-// It returns all errors found (not just the first).
-func Validate(spec *parser.Spec) []error {
+// The registry is used to look up plugin-specific assertion targets
+// (e.g., "status" for http, "exit_code" for process). It must not be nil.
+func Validate(s *parser.Spec, registry *spec.Registry) []error {
 	v := &validator{
-		models: buildModelRegistry(spec.Models),
+		models:   buildModelRegistry(s.Models),
+		registry: registry,
 	}
 
-	v.validateServiceRefs(spec)
+	v.validateServiceRefs(s)
 
-	for _, scope := range spec.Scopes {
+	for _, scope := range s.Scopes {
 		v.scope = scope.Name
 		v.validateContract(scope)
 		v.validateScenarios(scope)
@@ -33,9 +36,10 @@ func Validate(spec *parser.Spec) []error {
 }
 
 type validator struct {
-	models map[string]*parser.Model
-	scope  string
-	errs   []error
+	models   map[string]*parser.Model
+	registry *spec.Registry
+	scope    string
+	errs     []error
 }
 
 func buildModelRegistry(models []*parser.Model) map[string]*parser.Model {
@@ -81,6 +85,9 @@ func (v *validator) validateThenBlock(sc *parser.Scenario, scope *parser.Scope) 
 
 	outputFields := buildFieldMap(scope.Contract.Output)
 
+	// Build set of plugin assertion targets (e.g., "status", "body", "header" for http).
+	pluginAssertions := v.pluginAssertionTargets(scope.Use)
+
 	for _, a := range sc.Then.Assertions {
 		// Skip plugin assertions (e.g., welcome@playwright.visible)
 		if a.Plugin != "" {
@@ -95,12 +102,37 @@ func (v *validator) validateThenBlock(sc *parser.Scenario, scope *parser.Scope) 
 		if a.Target == "error" {
 			continue
 		}
+
 		fieldName := topLevelField(a.Target)
+
+		// Check plugin-specific built-in targets (e.g., "status" for http).
+		if pluginAssertions[fieldName] {
+			continue
+		}
+
 		if _, ok := outputFields[fieldName]; !ok {
 			v.errorf("scope %q, scenario %q: then target %q does not match any output field",
 				v.scope, sc.Name, a.Target)
 		}
 	}
+}
+
+// pluginAssertionTargets returns the set of built-in assertion target names
+// for the given plugin (from the registry). Returns nil if the plugin is
+// not found or has no assertions.
+func (v *validator) pluginAssertionTargets(pluginName string) map[string]bool {
+	if v.registry == nil || pluginName == "" {
+		return nil
+	}
+	def, ok := v.registry.Plugin(pluginName)
+	if !ok {
+		return nil
+	}
+	targets := make(map[string]bool, len(def.Assertions))
+	for name := range def.Assertions {
+		targets[name] = true
+	}
+	return targets
 }
 
 func buildFieldMap(fields []*parser.Field) map[string]*parser.Field {

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -6,7 +6,36 @@ import (
 	"testing"
 
 	"github.com/bamsammich/speclang/v2/internal/parser"
+	"github.com/bamsammich/speclang/v2/pkg/spec"
 )
+
+// testRegistry returns a registry with http and process plugin assertions
+// registered, matching the built-in plugin definitions.
+func testRegistry() *spec.Registry {
+	r := spec.NewRegistry()
+	r.Register("http", spec.PluginDef{
+		Assertions: map[string]spec.AssertionDef{
+			"status": {Type: "int"},
+			"body":   {Type: "any"},
+			"header": {Type: "string"},
+		},
+	})
+	r.Register("process", spec.PluginDef{
+		Assertions: map[string]spec.AssertionDef{
+			"exit_code": {Type: "int"},
+			"stdout":    {Type: "any"},
+			"stderr":    {Type: "string"},
+		},
+	})
+	r.Register("playwright", spec.PluginDef{
+		Assertions: map[string]spec.AssertionDef{
+			"visible": {Type: "bool"},
+			"text":    {Type: "string"},
+			"count":   {Type: "int"},
+		},
+	})
+	return r
+}
 
 func TestValidate_UnknownTypeInContract(t *testing.T) {
 	t.Parallel()
@@ -24,7 +53,7 @@ func TestValidate_UnknownTypeInContract(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) == 0 {
 		t.Fatal("expected validation error for unknown type Widget")
 	}
@@ -60,7 +89,7 @@ func TestValidate_KnownModelPasses(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors, got: %v", errs)
 	}
@@ -85,7 +114,7 @@ func TestValidate_UnknownArrayElementType(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) == 0 {
 		t.Fatal("expected validation error for unknown array element type Widget")
 	}
@@ -120,7 +149,7 @@ func TestValidate_GivenLiteralTypeMismatch(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) == 0 {
 		t.Fatal("expected validation error for type mismatch")
 	}
@@ -165,7 +194,7 @@ func TestValidate_GivenLiteralCorrectType(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors, got: %v", errs)
 	}
@@ -208,7 +237,7 @@ func TestValidate_NullOnlyForOptional(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 1 {
 		t.Fatalf("expected 1 error (null on required), got %d: %v", len(errs), errs)
 	}
@@ -252,7 +281,7 @@ func TestValidate_ArrayElementTypeMismatch(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 1 {
 		t.Fatalf("expected 1 error for string in []int, got %d: %v", len(errs), errs)
 	}
@@ -319,7 +348,7 @@ func TestValidate_ArrayOfObjectsFieldCheck(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) == 0 {
 		t.Fatal("expected errors for unknown field 'colour'")
 	}
@@ -378,7 +407,7 @@ func TestValidate_NestedArrays(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 1 {
 		t.Fatalf("expected 1 error for string in nested [][]int, got %d: %v", len(errs), errs)
 	}
@@ -426,7 +455,7 @@ func TestValidate_ObjectLiteralUnknownField(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 1 {
 		t.Fatalf("expected 1 error for unknown field email, got %d: %v", len(errs), errs)
 	}
@@ -476,7 +505,7 @@ func TestValidate_ObjectLiteralFieldTypeMismatch(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 1 {
 		t.Fatalf("expected 1 error for balance type mismatch, got %d: %v", len(errs), errs)
 	}
@@ -520,7 +549,7 @@ func TestValidate_ObjectLiteralValidPasses(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors, got: %v", errs)
 	}
@@ -559,7 +588,7 @@ func TestValidate_GivenMissingRequiredField(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 1 {
 		t.Fatalf("expected 1 error for missing 'to', got %d: %v", len(errs), errs)
 	}
@@ -594,7 +623,7 @@ func TestValidate_GivenWithCallsSkipsCompleteness(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors (given with calls skips completeness), got: %v", errs)
 	}
@@ -630,7 +659,7 @@ func TestValidate_WhenScenarioSkipsCompleteness(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors (when scenario skips completeness), got: %v", errs)
 	}
@@ -672,7 +701,7 @@ func TestValidate_ThenUnknownField(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 1 {
 		t.Fatalf("expected 1 error for unknown then target, got %d: %v", len(errs), errs)
 	}
@@ -729,7 +758,7 @@ func TestValidate_ThenDotPathValid(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors, got: %v", errs)
 	}
@@ -771,7 +800,7 @@ func TestValidate_ThenPluginAssertionSkipped(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors (plugin assertions skipped), got: %v", errs)
 	}
@@ -816,7 +845,7 @@ func TestValidate_MultipleErrors(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) < 3 {
 		t.Fatalf(
 			"expected at least 3 errors (type mismatch + missing field + bad then target), got %d: %v",
@@ -870,7 +899,7 @@ func TestValidate_ServiceRefValid(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors for valid service ref, got: %v", errs)
 	}
@@ -886,7 +915,7 @@ func TestValidate_ServiceRefUndeclared(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 1 {
 		t.Fatalf("expected 1 error for undeclared service ref, got %d: %v", len(errs), errs)
 	}
@@ -907,7 +936,7 @@ func TestValidate_ServiceRefWithCompose(t *testing.T) {
 		},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	if len(errs) != 0 {
 		t.Fatalf("expected no errors when compose is set, got: %v", errs)
 	}
@@ -945,7 +974,7 @@ func TestValidate_ErrorPseudoFieldAllowed(t *testing.T) {
 		}},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	for _, e := range errs {
 		if contains(e.Error(), "error") && contains(e.Error(), "output field") {
 			t.Errorf("error pseudo-field should be allowed, got: %v", e)
@@ -981,7 +1010,7 @@ func TestValidate_ErrorContractFieldStillValidated(t *testing.T) {
 		}},
 	}
 
-	errs := Validate(spec)
+	errs := Validate(spec, testRegistry())
 	found := false
 	for _, e := range errs {
 		if contains(e.Error(), "nonexistent") {
@@ -993,5 +1022,89 @@ func TestValidate_ErrorContractFieldStillValidated(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected validation error for 'nonexistent' field")
+	}
+}
+
+func TestValidate_PluginAssertionTargetsAllowed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		plugin string
+		target string
+	}{
+		{"http status", "http", "status"},
+		{"http body", "http", "body"},
+		{"http header", "http", "header"},
+		{"process exit_code", "process", "exit_code"},
+		{"process stdout", "process", "stdout"},
+		{"process stderr", "process", "stderr"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			spec := &parser.Spec{
+				Scopes: []*parser.Scope{{
+					Name: "test",
+					Use:  tt.plugin,
+					Contract: &parser.Contract{
+						Input:  []*parser.Field{},
+						Output: []*parser.Field{{Name: "data", Type: parser.TypeExpr{Name: "string"}}},
+					},
+					Scenarios: []*parser.Scenario{{
+						Name:  "check",
+						Given: &parser.Block{},
+						Then: &parser.Block{
+							Assertions: []*parser.Assertion{
+								{Target: tt.target, Expected: parser.LiteralInt{Value: 200}, Operator: "=="},
+							},
+						},
+					}},
+				}},
+			}
+
+			errs := Validate(spec, testRegistry())
+			for _, e := range errs {
+				if contains(e.Error(), tt.target) {
+					t.Errorf("%s should be allowed as assertion target for %s plugin, got: %v",
+						tt.target, tt.plugin, e)
+				}
+			}
+		})
+	}
+}
+
+func TestValidate_UnknownTargetStillRejected(t *testing.T) {
+	t.Parallel()
+	spec := &parser.Spec{
+		Scopes: []*parser.Scope{{
+			Name: "test",
+			Use:  "http",
+			Contract: &parser.Contract{
+				Input:  []*parser.Field{},
+				Output: []*parser.Field{{Name: "data", Type: parser.TypeExpr{Name: "string"}}},
+			},
+			Scenarios: []*parser.Scenario{{
+				Name:  "check",
+				Given: &parser.Block{},
+				Then: &parser.Block{
+					Assertions: []*parser.Assertion{
+						{Target: "nonexistent", Expected: parser.LiteralInt{Value: 42}, Operator: "=="},
+					},
+				},
+			}},
+		}},
+	}
+
+	errs := Validate(spec, testRegistry())
+	found := false
+	for _, e := range errs {
+		if contains(e.Error(), "nonexistent") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected validation error for unknown target 'nonexistent'")
 	}
 }

--- a/pkg/specrun/specrun.go
+++ b/pkg/specrun/specrun.go
@@ -30,8 +30,13 @@ func ParseFile(path string, imports spec.ImportRegistry) (*spec.Spec, error) {
 }
 
 // Validate checks a spec for semantic errors.
-func Validate(s *spec.Spec) []error {
-	return validator.Validate(s)
+// The registry is used to look up plugin-specific assertion targets.
+// If nil, DefaultRegistry() is used.
+func Validate(s *spec.Spec, registry *spec.Registry) []error {
+	if registry == nil {
+		registry = DefaultRegistry()
+	}
+	return validator.Validate(s, registry)
 }
 
 // FormatErrors formats validation errors into a human-readable string.

--- a/specs/parse.spec
+++ b/specs/parse.spec
@@ -100,6 +100,17 @@ scope parse_valid {
       name: "Quantifiers"
     }
   }
+
+  # Verifies that plugin assertion targets (e.g., "status" for http) pass validation.
+  scenario plugin_assertion_target {
+    given {
+      file: "testdata/self/plugin_assertion_target.spec"
+    }
+    then {
+      exit_code: 0
+      name: "PluginAssertionTarget"
+    }
+  }
 }
 
 # Verifies the parser rejects malformed specs with a non-zero exit code.

--- a/testdata/self/plugin_assertion_target.spec
+++ b/testdata/self/plugin_assertion_target.spec
@@ -1,0 +1,21 @@
+spec PluginAssertionTarget {
+  scope test_http {
+    use http
+    config {
+      path: "/test"
+      method: "GET"
+    }
+    contract {
+      input {}
+      output {
+        data: string
+      }
+    }
+    scenario check_status {
+      given {}
+      then {
+        status: 200
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- The validator now consults the plugin registry when validating `then`-block assertion targets, so built-in targets like `status` (http), `exit_code` (process) are accepted
- `Validate()` signature updated to accept `*spec.Registry` — all call sites updated (no backward-compat wrapper)
- Added self-verification spec fixture (`testdata/self/plugin_assertion_target.spec`) to catch regressions

Fixes #92

## Test plan
- [x] Validator test: `status`, `body`, `header` pass validation in http scope
- [x] Validator test: `exit_code`, `stdout`, `stderr` pass validation in process scope
- [x] Validator test: unknown targets still rejected
- [x] Self-verification fixture: spec with `status: 200` in http scope parses + validates
- [x] Full test suite passes (`go test ./...`)