### PR TITLE
fix(runner): resolve body references in given/before steps

### DIFF
--- a/internal/runner/before_test.go
+++ b/internal/runner/before_test.go
@@ -234,6 +234,87 @@ func TestBeforeFailureReturnsError(t *testing.T) {
 	}
 }
 
+// TestBeforeBodyRefResolution verifies that body.field references in before/given
+// steps resolve from the previous action's response (#97).
+func TestBeforeBodyRefResolution(t *testing.T) {
+	adp := &bodyRefAdapter{}
+
+	// before block: post to login (returns {"access_token":"tok123"}),
+	// then call header with "Bearer " + body.access_token
+	beforeBlock := &spec.Block{
+		Steps: []spec.GivenStep{
+			&spec.Call{Namespace: "http", Method: "post", Args: []spec.Expr{
+				spec.LiteralString{Value: "/auth/login"},
+				spec.ObjectLiteral{},
+			}},
+			&spec.Call{Namespace: "http", Method: "header", Args: []spec.Expr{
+				spec.LiteralString{Value: "Authorization"},
+				spec.BinaryOp{
+					Left:  spec.LiteralString{Value: "Bearer "},
+					Op:    "+",
+					Right: spec.FieldRef{Path: "body.access_token"},
+				},
+			}},
+		},
+	}
+
+	s := minimalSpec([]*spec.Scope{
+		{
+			Name:      "test_scope",
+			Use:       "http",
+			Config:    map[string]spec.Expr{"method": spec.LiteralString{Value: "POST"}, "path": spec.LiteralString{Value: "/api/test"}},
+			Before:    beforeBlock,
+			Contract:  minimalContract(),
+			Scenarios: []*spec.Scenario{givenScenario("basic", 42)},
+		},
+	})
+
+	r := runner.New(s, map[string]adapter.Adapter{"http": adp}, 1)
+	r.SetN(1)
+	_, err := r.Verify()
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+
+	// The header call should have received "Bearer tok123" as the second arg.
+	if adp.lastHeaderValue != "Bearer tok123" {
+		t.Errorf("expected header value 'Bearer tok123', got %q", adp.lastHeaderValue)
+	}
+}
+
+// bodyRefAdapter returns a JSON body from "post" and records "header" args.
+type bodyRefAdapter struct {
+	lastHeaderValue string
+}
+
+func (a *bodyRefAdapter) Init(map[string]string) error { return nil }
+func (a *bodyRefAdapter) Reset() error                 { return nil }
+func (a *bodyRefAdapter) Close() error                 { return nil }
+
+func (a *bodyRefAdapter) Action(name string, args json.RawMessage) (*spec.Response, error) {
+	switch name {
+	case "post":
+		return &spec.Response{
+			OK:     true,
+			Actual: json.RawMessage(`{"access_token":"tok123"}`),
+		}, nil
+	case "header":
+		var rawArgs []json.RawMessage
+		if err := json.Unmarshal(args, &rawArgs); err == nil && len(rawArgs) >= 2 {
+			var val string
+			json.Unmarshal(rawArgs[1], &val)
+			a.lastHeaderValue = val
+		}
+		return &spec.Response{OK: true, Actual: json.RawMessage(`{}`)}, nil
+	default:
+		return &spec.Response{OK: true, Actual: json.RawMessage(`{}`)}, nil
+	}
+}
+
+func (a *bodyRefAdapter) Assert(property, locator string, expected json.RawMessage) (*spec.Response, error) {
+	return &spec.Response{OK: true, Actual: expected}, nil
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchSubstring(s, substr)
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -380,10 +380,10 @@ func (sr *scopeRunner) executeGivenSteps(steps []parser.GivenStep) (map[string]a
 	for _, step := range steps {
 		switch s := step.(type) {
 		case *parser.Assignment:
-			val, _ := generator.Eval(s.Value, nil)
+			val, _ := generator.Eval(s.Value, input)
 			setPath(input, s.Path, val)
 		case *parser.Call:
-			args, err := sr.marshalCallArgs(s)
+			args, err := sr.marshalCallArgs(s, input)
 			if err != nil {
 				return nil, fmt.Errorf("marshaling args for %s.%s: %w", s.Namespace, s.Method, err)
 			}
@@ -400,6 +400,13 @@ func (sr *scopeRunner) executeGivenSteps(steps []parser.GivenStep) (map[string]a
 					resp.Error,
 				)
 			}
+			// Make the action response available as "body" for subsequent steps.
+			if len(resp.Actual) > 0 {
+				var parsed any
+				if err := json.Unmarshal(resp.Actual, &parsed); err == nil {
+					input["body"] = parsed
+				}
+			}
 		}
 	}
 	return input, nil
@@ -407,7 +414,9 @@ func (sr *scopeRunner) executeGivenSteps(steps []parser.GivenStep) (map[string]a
 
 // marshalCallArgs converts Call expression arguments to JSON for the adapter.
 // FieldRef args are resolved as locator names from the spec's locators map.
-func (sr *scopeRunner) marshalCallArgs(call *parser.Call) (json.RawMessage, error) {
+// The ctx provides the accumulated step context for expression evaluation
+// (e.g., "body" from a previous action response).
+func (sr *scopeRunner) marshalCallArgs(call *parser.Call, ctx map[string]any) (json.RawMessage, error) {
 	var resolved []any
 	for _, arg := range call.Args {
 		switch a := arg.(type) {
@@ -416,11 +425,15 @@ func (sr *scopeRunner) marshalCallArgs(call *parser.Call) (json.RawMessage, erro
 			if selector, ok := sr.runner.spec.Locators[a.Path]; ok {
 				resolved = append(resolved, selector)
 			} else {
-				// Not a locator — pass the name as-is (could be a variable)
-				resolved = append(resolved, a.Path)
+				// Try resolving as a context reference (e.g., body.access_token)
+				if val, ok := generator.Eval(a, ctx); ok {
+					resolved = append(resolved, val)
+				} else {
+					resolved = append(resolved, a.Path)
+				}
 			}
 		default:
-			val, _ := generator.Eval(arg, nil)
+			val, _ := generator.Eval(arg, ctx)
 			resolved = append(resolved, val)
 		}
 	}


### PR DESCRIPTION
## Summary
- `body.access_token` and other response references now resolve correctly in multi-step `given` and `before` blocks
- `executeGivenSteps` populates `input["body"]` from each action's `resp.Actual` so subsequent steps can reference response fields
- `marshalCallArgs` now receives the accumulated step context and passes it to `generator.Eval` (was `nil`)
- `FieldRef` args in calls now try context resolution before falling back to raw path string

Fixes #97

## Root cause
`marshalCallArgs` evaluated all expressions with `generator.Eval(arg, nil)` — nil context. Response data from prior actions was never fed back into the expression evaluator. This made `body.access_token` silently resolve to nothing.

## Test plan
- [x] `TestBeforeBodyRefResolution`: before block posts to login, references `body.access_token` in subsequent `header` call — verifies "Bearer tok123" is received
- [x] All existing tests pass (`go test ./...`)