### PR TITLE
fix(migrate): convert body.field refs in given blocks

### DIFF
--- a/internal/migrate/emitter.go
+++ b/internal/migrate/emitter.go
@@ -296,7 +296,7 @@ func (w *v3Writer) emitBlock(b *spec.Block, kind string, scopeAdapter string, lo
 	// Steps (given/before/after blocks)
 	if len(b.Steps) > 0 {
 		steps := b.Steps
-		if kind == "before" || kind == "after" {
+		if kind == "before" || kind == "after" || kind == "given" {
 			steps = transformBodyRefs(steps, scopeAdapter)
 		}
 		for _, step := range steps {

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -23,6 +23,7 @@ func TestGoldenFiles(t *testing.T) {
 		{"http_basic", "testdata/http_basic.v2.spec", "testdata/http_basic.v3.spec"},
 		{"playwright", "testdata/playwright.v2.spec", "testdata/playwright.v3.spec"},
 		{"process", "testdata/process.v2.spec", "testdata/process.v3.spec"},
+		{"given_body_ref", "testdata/given_body_ref.v2.spec", "testdata/given_body_ref.v3.spec"},
 	}
 
 	for _, tt := range tests {
@@ -370,6 +371,123 @@ func TestFormatTypeExpr(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestTransformBodyRefs_GivenBlock verifies body refs in given blocks are converted.
+func TestTransformBodyRefs_GivenBlock(t *testing.T) {
+	t.Parallel()
+
+	steps := []spec.GivenStep{
+		&spec.Call{Namespace: "http", Method: "post", Args: []spec.Expr{
+			spec.LiteralString{Value: "/api/groups"},
+			spec.ObjectLiteral{Fields: []*spec.ObjField{{Key: "name", Value: spec.LiteralString{Value: "Test"}}}},
+		}},
+		&spec.Call{Namespace: "http", Method: "post", Args: []spec.Expr{
+			spec.BinaryOp{
+				Left:  spec.LiteralString{Value: "/api/groups/"},
+				Op:    "+",
+				Right: spec.FieldRef{Path: "body.group.id"},
+			},
+		}},
+	}
+
+	result := transformBodyRefs(steps, "http")
+	if len(result) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(result))
+	}
+
+	// First step should be wrapped in a let binding.
+	if _, ok := result[0].(*spec.LetBinding); !ok {
+		t.Errorf("expected first step to be LetBinding, got %T", result[0])
+	}
+}
+
+// TestTransformBodyRefs_Assignment verifies body refs in assignment values are converted.
+func TestTransformBodyRefs_Assignment(t *testing.T) {
+	t.Parallel()
+
+	steps := []spec.GivenStep{
+		&spec.Call{Namespace: "http", Method: "post", Args: []spec.Expr{
+			spec.LiteralString{Value: "/api/groups"},
+		}},
+		&spec.Assignment{Path: "group_id", Value: spec.FieldRef{Path: "body.group.id"}},
+	}
+
+	result := transformBodyRefs(steps, "http")
+
+	// First step should be let binding.
+	lb, ok := result[0].(*spec.LetBinding)
+	if !ok {
+		t.Fatalf("expected LetBinding, got %T", result[0])
+	}
+
+	// Assignment should reference the let variable, not body.
+	assign, ok := result[1].(*spec.Assignment)
+	if !ok {
+		t.Fatalf("expected Assignment, got %T", result[1])
+	}
+	ref, ok := assign.Value.(spec.FieldRef)
+	if !ok {
+		t.Fatalf("expected FieldRef value, got %T", assign.Value)
+	}
+	if !strings.HasPrefix(ref.Path, lb.Name+".") {
+		t.Errorf("assignment value %q should reference %q", ref.Path, lb.Name)
+	}
+}
+
+// TestTransformBodyRefs_NonAdjacent verifies body ref conversion works with intervening steps.
+func TestTransformBodyRefs_NonAdjacent(t *testing.T) {
+	t.Parallel()
+
+	steps := []spec.GivenStep{
+		&spec.Call{Namespace: "http", Method: "post", Args: []spec.Expr{
+			spec.LiteralString{Value: "/api/init"},
+		}},
+		&spec.Assignment{Path: "name", Value: spec.LiteralString{Value: "test"}},
+		// body ref is 2 steps after the call
+		&spec.Call{Namespace: "http", Method: "post", Args: []spec.Expr{
+			spec.FieldRef{Path: "body.token"},
+		}},
+	}
+
+	result := transformBodyRefs(steps, "http")
+
+	// First step should be wrapped in let binding.
+	if _, ok := result[0].(*spec.LetBinding); !ok {
+		t.Errorf("expected first step to be LetBinding, got %T", result[0])
+	}
+	// Assignment should be unchanged.
+	if _, ok := result[1].(*spec.Assignment); !ok {
+		t.Errorf("expected second step to be Assignment, got %T", result[1])
+	}
+}
+
+// TestTransformBodyRefs_MultipleRefs verifies unique variable names for multiple calls.
+func TestTransformBodyRefs_MultipleRefs(t *testing.T) {
+	t.Parallel()
+
+	steps := []spec.GivenStep{
+		&spec.Call{Namespace: "http", Method: "post", Args: []spec.Expr{
+			spec.LiteralString{Value: "/api/first"},
+		}},
+		&spec.Assignment{Path: "first_id", Value: spec.FieldRef{Path: "body.id"}},
+		&spec.Call{Namespace: "http", Method: "post", Args: []spec.Expr{
+			spec.LiteralString{Value: "/api/second"},
+		}},
+		&spec.Assignment{Path: "second_id", Value: spec.FieldRef{Path: "body.id"}},
+	}
+
+	result := transformBodyRefs(steps, "http")
+
+	// Both calls should be wrapped with different variable names.
+	lb0, ok0 := result[0].(*spec.LetBinding)
+	lb2, ok2 := result[2].(*spec.LetBinding)
+	if !ok0 || !ok2 {
+		t.Fatalf("expected both calls wrapped, got types: %T, %T", result[0], result[2])
+	}
+	if lb0.Name == lb2.Name {
+		t.Errorf("variable names should differ, both are %q", lb0.Name)
 	}
 }
 

--- a/internal/migrate/testdata/given_body_ref.v2.spec
+++ b/internal/migrate/testdata/given_body_ref.v2.spec
@@ -1,0 +1,40 @@
+spec GroupAPI {
+  description: "Group management API"
+
+  target {
+    base_url: "http://localhost:8080"
+  }
+
+  scope leave_group {
+    use http
+    config {
+      path: "/api/v1/groups/:group_id/leave"
+      method: "POST"
+    }
+
+    before {
+      http.post("/api/v1/auth/login", { provider: "google", id_token: "test-token" })
+      http.header("Authorization", "Bearer " + body.access_token)
+    }
+
+    contract {
+      input {
+        group_id: string
+      }
+      output {
+        success: bool?
+        error: string?
+      }
+    }
+
+    scenario last_manager_cannot_leave {
+      given {
+        http.post("/api/v1/groups", { name: "Solo Manager Group" })
+        group_id: body.group.id
+      }
+      then {
+        error: "last_manager_cannot_leave"
+      }
+    }
+  }
+}

--- a/internal/migrate/testdata/given_body_ref.v3.spec
+++ b/internal/migrate/testdata/given_body_ref.v3.spec
@@ -1,0 +1,40 @@
+spec GroupAPI {
+  description: "Group management API"
+
+  http {
+    base_url: "http://localhost:8080"
+  }
+
+  scope leave_group {
+    action leave_group(group_id: string) {
+      let result = http.post("/api/v1/groups/:group_id/leave", { group_id: group_id })
+      return result
+    }
+
+    before {
+      let r0 = http.post("/api/v1/auth/login", { provider: "google", id_token: "test-token" })
+      http.header("Authorization", "Bearer " + r0.access_token)
+    }
+
+    contract {
+      input {
+        group_id: string
+      }
+      output {
+        success: bool?
+        error: string?
+      }
+      action: leave_group
+    }
+
+    scenario last_manager_cannot_leave {
+      given {
+        let r0 = http.post("/api/v1/groups", { name: "Solo Manager Group" })
+        group_id: r0.group.id
+      }
+      then {
+        error == "last_manager_cannot_leave"
+      }
+    }
+  }
+}

--- a/internal/migrate/transform.go
+++ b/internal/migrate/transform.go
@@ -244,33 +244,32 @@ func inferAdapterConfigs(s *spec.Spec) map[string]map[string]string {
 	return configs
 }
 
-// transformBodyRefs detects implicit body.X references in before/after block steps
-// and wraps preceding adapter calls with let bindings.
+// transformBodyRefs detects implicit body.X references in block steps and wraps
+// preceding adapter calls with let bindings. Handles non-adjacent references
+// (e.g., an assignment between the call and the body ref) and multiple calls
+// in the same block with unique variable names.
 func transformBodyRefs(steps []spec.GivenStep, scopeAdapter string) []spec.GivenStep {
 	if len(steps) == 0 {
 		return steps
 	}
 
 	result := make([]spec.GivenStep, 0, len(steps))
-	var lastCallIdx int = -1
+	lastCallResultIdx := -1 // index in result slice of last unwrapped call
+	varCounter := 0
 
-	for i, step := range steps {
-		// Check if this step contains body.X references
-		hasBodyRef := stepHasBodyRef(step)
-
-		if hasBodyRef && lastCallIdx >= 0 && lastCallIdx == i-1 {
-			// Wrap the previous call in a let binding
-			prevStep := result[len(result)-1]
-			result[len(result)-1] = wrapCallInLet(prevStep, "result")
-
-			// Rewrite body.X → result.X in current step
-			step = rewriteBodyRefs(step, "result")
+	for _, step := range steps {
+		if stepHasBodyRef(step) && lastCallResultIdx >= 0 {
+			varName := fmt.Sprintf("r%d", varCounter)
+			varCounter++
+			result[lastCallResultIdx] = wrapCallInLet(result[lastCallResultIdx], varName)
+			step = rewriteBodyRefs(step, varName)
+			lastCallResultIdx = -1 // consumed
 		}
 
 		// Track calls for body ref resolution
 		switch step.(type) {
 		case *spec.Call, *spec.AdapterCall:
-			lastCallIdx = i
+			lastCallResultIdx = len(result)
 		}
 
 		result = append(result, step)
@@ -294,6 +293,8 @@ func stepHasBodyRef(step spec.GivenStep) bool {
 				return true
 			}
 		}
+	case *spec.Assignment:
+		return exprHasBodyRef(s.Value)
 	}
 	return false
 }
@@ -357,6 +358,11 @@ func rewriteBodyRefs(step spec.GivenStep, varName string) spec.GivenStep {
 			Adapter: s.Adapter,
 			Method:  s.Method,
 			Args:    newArgs,
+		}
+	case *spec.Assignment:
+		return &spec.Assignment{
+			Path:  s.Path,
+			Value: rewriteBodyRefsInExpr(s.Value, varName),
 		}
 	}
 	return step


### PR DESCRIPTION
## Summary

- Fix `body.X` references in `given` blocks not being converted to `let` bindings during v2→v3 migration
- Fix `body.X` in assignment values (e.g., `group_id: body.group.id`) not being detected
- Fix non-adjacent body refs (assignment between call and ref) not being converted

## Root cause

Three defects in `transformBodyRefs`:
1. Gating condition in `emitter.go` only ran the transform on `before`/`after` blocks, excluding `given`
2. `stepHasBodyRef` only checked `Call` and `AdapterCall` args, missing `Assignment` values
3. Strict adjacency check (`lastCallIdx == i-1`) failed when any step sat between the call and the body ref

## Test plan

- [x] `TestTransformBodyRefs_GivenBlock` — body ref in given block converted
- [x] `TestTransformBodyRefs_Assignment` — assignment value `body.X` converted
- [x] `TestTransformBodyRefs_NonAdjacent` — intervening steps don't break conversion
- [x] `TestTransformBodyRefs_MultipleRefs` — unique var names for multiple calls
- [x] Golden file test with exact reproduction from #101
- [x] All 557 tests pass

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)